### PR TITLE
navigating/selecting services fix

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/groovyconsole/clientlibs/js/services.js
+++ b/ui.apps/src/main/content/jcr_root/apps/groovyconsole/clientlibs/js/services.js
@@ -7,12 +7,13 @@ $(function () {
 
                 scriptEditor.navigateFileEnd();
 
-                if (scriptEditor.getCursorPosition().column > 0) {
+                if (scriptEditor.getCursorPosition().column > 0 ) {
                     scriptEditor.insert('\n\n');
                 }
 
-                scriptEditor.insert(declaration);
-
+                if((event.keyCode === 13 || event.which === 13)) {
+                    scriptEditor.insert(declaration);
+                }
                 return '';
             }
         });


### PR DESCRIPTION
Solved the issue: Minor UI issue: navigating through Services dropdown using ↑/↓ keys adds all the touched services to the console #43