### PR TITLE
Create /var/groovyconsole/audit as sling:Folder to make type conflicts

### DIFF
--- a/ui.config/src/main/content/jcr_root/apps/groovyconsole-config/osgiconfig/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-groovyconsole.config
+++ b/ui.config/src/main/content/jcr_root/apps/groovyconsole-config/osgiconfig/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-groovyconsole.config
@@ -1,9 +1,7 @@
 scripts=[
 "
 create path /conf/groovyconsole/replication(sling:Folder)
-create path /conf/groovyconsole/scripts(sling:Folder)
-
-create path /var/groovyconsole/audit(nt:unstructured)
+create path /var/groovyconsole/audit(sling:Folder)
 
 create service user aem-groovy-console-service with path system/aem-groovy-console
 set ACL for aem-groovy-console-service

--- a/ui.content/src/main/content/jcr_root/conf/groovyconsole/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/groovyconsole/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/ui.content/src/main/content/jcr_root/conf/groovyconsole/scripts/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/groovyconsole/scripts/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>


### PR DESCRIPTION
less likely

Only create those nodes via repoinit which are not created implicitly through packages.

This closes #50