### PR TITLE
Upgrade Groovy to 4.0.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Workaround for [SLING-13123](https://issues.apache.org/jira/browse/SLING-13123): Groovy bundles became fragments in 4.0.23+, but the Sling installer's `RestartActiveBundlesTask` would still try to restart them and fail. New `GroovyBundleToFragmentFixer` removes the fragments from that task. No-op when the Sling installer is not present (e.g. AEMaaCS) or when installer-core ≥ 3.14.6 is detected.
+- IT coverage for fragment-contributed extension methods (`Date.format`, `groovy.json.*`, `groovy.xml.*`)
 
 ### Fixed
 
+- `groovy-osgi` activator now correctly registers extension modules contributed by fragment bundles (e.g. `groovy-dateutil`, `groovy-json`, `groovy-xml`). Without this, `Date.format(String, TimeZone)` and similar fragment-contributed extension methods threw `MissingMethodException` at runtime. The activator walks to the host bundle's classloader for fragments and refreshes any modules pre-registered by Groovy's own scanner with a stale classloader.
 - Move `maven-gpg-plugin` to the `release` profile so local builds don't require a GPG key
 - Bump `aemanalyser-maven-plugin` from 1.5.8 to 1.6.18 (was emitting an outdated-version warning)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade Groovy from 4.0.22 to 4.0.31
+
+### Added
+
+- Workaround for [SLING-13123](https://issues.apache.org/jira/browse/SLING-13123): Groovy bundles became fragments in 4.0.23+, but the Sling installer's `RestartActiveBundlesTask` would still try to restart them and fail. New `GroovyBundleToFragmentFixer` removes the fragments from that task. No-op when the Sling installer is not present (e.g. AEMaaCS) or when installer-core ≥ 3.14.6 is detected.
+
+### Fixed
+
+- Move `maven-gpg-plugin` to the `release` profile so local builds don't require a GPG key
+- Bump `aemanalyser-maven-plugin` from 1.5.8 to 1.6.18 (was emitting an outdated-version warning)
+
 ## [19.0.9] - 2026-05-03
 
 ### Added

--- a/bundle/src/main/groovy/be/orbinson/aem/groovy/console/impl/GroovyBundleToFragmentFixer.groovy
+++ b/bundle/src/main/groovy/be/orbinson/aem/groovy/console/impl/GroovyBundleToFragmentFixer.groovy
@@ -1,0 +1,86 @@
+package be.orbinson.aem.groovy.console.impl
+
+import groovy.util.logging.Slf4j
+import org.osgi.framework.BundleContext
+import org.osgi.framework.Version
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+
+/**
+ * Workaround for SLING-13123: when Groovy bundles changed from bundles to fragments
+ * (4.0.23+), the Sling installer's RestartActiveBundlesTask tries to restart them and fails.
+ * Fixed in installer-core 3.14.6; this fixer is a no-op when that version (or higher) is present
+ * or when the Sling installer is not running at all (e.g. AEMaaCS).
+ */
+@Component(
+        service = GroovyBundleToFragmentFixer.class,
+        immediate = true
+)
+@Slf4j("LOG")
+class GroovyBundleToFragmentFixer {
+
+    static final List<String> GROOVY_BUNDLES_TO_FRAGMENT = [
+            "groovy-dateutil",
+            "groovy-json",
+            "groovy-nio",
+            "groovy-templates",
+            "groovy-xml",
+            "groovy-yaml"
+    ]
+
+    static final String ENTITY_ID = "org.apache.sling.installer.core.restart.bundles:org.apache.sling.installer.core.restart.bundles"
+    static final String SLING_INSTALLER_CORE_BUNDLE = "org.apache.sling.installer.core"
+    static final Version FIXED_VERSION = new Version("3.14.6")
+
+    @Activate
+    protected void activate(BundleContext bundleContext) {
+        try {
+            if (isInstallerCoreFixed(bundleContext)) {
+                LOG.debug("Sling Installer Core >= {}, skipping fragment fixer", FIXED_VERSION)
+                return
+            }
+            def serviceRef = bundleContext.getServiceReference("org.apache.sling.installer.api.OsgiInstaller")
+            if (serviceRef == null) {
+                LOG.debug("OsgiInstaller service not available, skipping fragment fixer")
+                return
+            }
+            try {
+                def osgiInstaller = bundleContext.getService(serviceRef)
+                fixGroovyBundlesToFragment(bundleContext, osgiInstaller)
+            } finally {
+                bundleContext.ungetService(serviceRef)
+            }
+        } catch (e) {
+            LOG.warn("Could not fix the groovy bundles to fragments", e)
+        }
+    }
+
+    private static boolean isInstallerCoreFixed(BundleContext bundleContext) {
+        def installerBundle = bundleContext.bundles.find { it.symbolicName == SLING_INSTALLER_CORE_BUNDLE }
+        installerBundle != null && installerBundle.version >= FIXED_VERSION
+    }
+
+    private static void fixGroovyBundlesToFragment(BundleContext bundleContext, def osgiInstaller) {
+        def activeResource = osgiInstaller.persistentList
+                ?.getEntityResourceList(ENTITY_ID)
+                ?.activeResource
+
+        if (activeResource != null) {
+            def bundleIds = activeResource.getAttribute("bundles")
+            if (bundleIds != null) {
+                def fragmentIds = bundleIds
+                        .collect { bundleId -> bundleContext.getBundle(bundleId) }
+                        .findAll { bundle -> bundle != null && GROOVY_BUNDLES_TO_FRAGMENT.contains(bundle.symbolicName) }
+                        .collect { bundle ->
+                            LOG.info("Removing {} from RestartActiveBundlesTask; bundle switched to a fragment.", bundle.symbolicName)
+                            bundle.symbolicName
+                        } as Set
+
+                bundleIds.removeAll(fragmentIds)
+                activeResource.setAttribute("bundles", bundleIds)
+                osgiInstaller.cleanupInstallableResources()
+            }
+        }
+    }
+
+}

--- a/bundle/src/test/groovy/be/orbinson/aem/groovy/console/impl/GroovyBundleToFragmentFixerTest.groovy
+++ b/bundle/src/test/groovy/be/orbinson/aem/groovy/console/impl/GroovyBundleToFragmentFixerTest.groovy
@@ -1,0 +1,20 @@
+package be.orbinson.aem.groovy.console.impl
+
+import org.junit.jupiter.api.Test
+import org.osgi.framework.BundleContext
+
+import static org.mockito.Mockito.*
+
+class GroovyBundleToFragmentFixerTest {
+
+    @Test
+    void "skips when OsgiInstaller is not present"() {
+        def bundleContext = mock(BundleContext)
+        when(bundleContext.bundles).thenReturn(new org.osgi.framework.Bundle[0])
+        when(bundleContext.getServiceReference("org.apache.sling.installer.api.OsgiInstaller")).thenReturn(null)
+
+        new GroovyBundleToFragmentFixer().activate(bundleContext)
+
+        verify(bundleContext).getServiceReference("org.apache.sling.installer.api.OsgiInstaller")
+    }
+}

--- a/groovy/groovy-osgi/src/main/java/groovy/osgi/activator/Activator.java
+++ b/groovy/groovy-osgi/src/main/java/groovy/osgi/activator/Activator.java
@@ -8,6 +8,9 @@ import org.codehaus.groovy.runtime.m12n.*;
 import org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl;
 import org.codehaus.groovy.util.FastArray;
 import org.osgi.framework.*;
+import org.osgi.framework.namespace.HostNamespace;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleWire;
 import org.osgi.framework.wiring.BundleWiring;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +25,11 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * An OSGi bundle activator for Groovy which adapts the {@link org.codehaus.groovy.runtime.m12n.ExtensionModuleScanner}
  * to the OSGi environment.
+ *
+ * <p>Since Groovy 4.0.23 several extensions (groovy-dateutil, groovy-json, groovy-nio,
+ * groovy-templates, groovy-xml, groovy-yaml) ship as <em>fragment</em> bundles attached to the
+ * {@code groovy} host. Fragments do not own a class loader, so we walk the host wire to obtain
+ * the classloader required to instantiate the extension classes.</p>
  */
 public class Activator implements BundleActivator, SynchronousBundleListener {
 
@@ -68,13 +76,15 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
     }
 
     protected void register(final Bundle bundle) {
-        LOG.debug("checking bundle " + bundle.getBundleId());
+        LOG.debug("checking bundle " + bundle.getBundleId() + " (" + bundle.getSymbolicName() + ")");
         if (containsExtensionModule(bundle) && hasCorrectMetaClassRegistry()) {
-            LOG.debug("Registering bundle for extension module: " + bundle.getBundleId());
+            LOG.info("Registering extension module from bundle {} ({})", bundle.getBundleId(), bundle.getSymbolicName());
             try {
                 registerExtensionModule(bundle);
             } catch (IOException e) {
-                LOG.error("Could not register extension module", e);
+                LOG.error("Could not register extension module from bundle " + bundle.getSymbolicName(), e);
+            } catch (RuntimeException e) {
+                LOG.error("Could not register extension module from bundle " + bundle.getSymbolicName(), e);
             }
         }
     }
@@ -102,29 +112,73 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
     private void registerExtensionModule(Bundle bundle) throws IOException {
         Properties properties = loadProperties(getExtensionModuleUrl(bundle));
         String moduleName = properties.getProperty(PropertiesModuleFactory.MODULE_NAME_KEY);
-        ExtensionModuleRegistry extensionModuleRegistry = (((MetaClassRegistryImpl) GroovySystem.getMetaClassRegistry()).getModuleRegistry());
-        if (!extensionModuleRegistry.hasModule(moduleName)) {
-            BundleWiring wiring = bundle.adapt(BundleWiring.class);
-            ExtensionModule extensionModule = MetaInfExtensionModule.newModule(properties, wiring.getClassLoader());
-            ExtensionModuleRegistry moduleRegistry = (((MetaClassRegistryImpl) GroovySystem.getMetaClassRegistry()).getModuleRegistry());
-            FastArray instanceMethods = (((MetaClassRegistryImpl) GroovySystem.getMetaClassRegistry()).getInstanceMethods());
-            FastArray staticMethods = (((MetaClassRegistryImpl) GroovySystem.getMetaClassRegistry()).getStaticMethods());
-            registerExtensionModule(extensionModule, moduleRegistry, instanceMethods, staticMethods);
-            bundleWrappers.put(bundle.getBundleId(), new BundleWrapper(bundle, extensionModule));
+        ClassLoader classLoader = resolveClassLoader(bundle);
+        if (classLoader == null) {
+            LOG.warn("No classloader available for bundle {} (id={}); skipping extension module {}",
+                    bundle.getSymbolicName(), bundle.getBundleId(), moduleName);
+            return;
         }
+
+        MetaClassRegistryImpl registry = (MetaClassRegistryImpl) GroovySystem.getMetaClassRegistry();
+        ExtensionModuleRegistry moduleRegistry = registry.getModuleRegistry();
+
+        // If the module is already in the registry — typically because Groovy's own
+        // ExtensionModuleScanner ran at MetaClassRegistry init with a stale classloader — drop it
+        // and rebuild with our bundle's wiring. This is necessary on Groovy 4.0.23+ where extension
+        // descriptors live in fragment bundles whose classloaders only become available after the
+        // host's wiring resolves.
+        if (moduleRegistry.hasModule(moduleName)) {
+            ExtensionModule existing = moduleRegistry.getModule(moduleName);
+            LOG.info("Re-registering extension module {} from {} (was registered by Groovy scanner; refreshing with bundle classloader)",
+                    moduleName, bundle.getSymbolicName());
+            moduleRegistry.removeModule(existing);
+        } else {
+            LOG.info("Registering extension module {} from {} using classloader {}",
+                    moduleName, bundle.getSymbolicName(), classLoader);
+        }
+
+        ExtensionModule extensionModule = MetaInfExtensionModule.newModule(properties, classLoader);
+        FastArray instanceMethods = registry.getInstanceMethods();
+        FastArray staticMethods = registry.getStaticMethods();
+        registerExtensionModule(extensionModule, moduleRegistry, instanceMethods, staticMethods);
+        bundleWrappers.put(bundle.getBundleId(), new BundleWrapper(bundle, extensionModule));
+    }
+
+    /**
+     * Returns the classloader to use when loading the extension classes referenced in the
+     * descriptor. For a regular bundle this is the bundle's own classloader; for a fragment
+     * bundle (which does not have a classloader of its own) we follow the host wire and use
+     * the host's classloader, which can resolve classes contributed by attached fragments.
+     */
+    private ClassLoader resolveClassLoader(Bundle bundle) {
+        BundleWiring wiring = bundle.adapt(BundleWiring.class);
+        if (wiring == null) {
+            return null;
+        }
+        ClassLoader classLoader = wiring.getClassLoader();
+        if (classLoader != null) {
+            // Regular bundle, or host bundle of fragments — its classloader can see both.
+            return classLoader;
+        }
+        // Fragment bundles do not own a classloader. Walk to the host bundle's wiring and
+        // use its classloader, which exposes both the host's classes and the fragment's.
+        BundleRevision revision = wiring.getRevision();
+        if (revision != null && (revision.getTypes() & BundleRevision.TYPE_FRAGMENT) != 0) {
+            List<BundleWire> hostWires = wiring.getRequiredWires(HostNamespace.HOST_NAMESPACE);
+            if (hostWires != null) {
+                for (BundleWire hostWire : hostWires) {
+                    BundleWiring hostWiring = hostWire.getProviderWiring();
+                    if (hostWiring != null && hostWiring.getClassLoader() != null) {
+                        return hostWiring.getClassLoader();
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     private void registerExtensionModule(ExtensionModule module, ExtensionModuleRegistry moduleRegistry, FastArray instanceMethods, FastArray staticMethods) {
-        if (moduleRegistry.hasModule(module.getName())) {
-            ExtensionModule loadedModule = moduleRegistry.getModule(module.getName());
-            if (loadedModule.getVersion().equals(module.getVersion())) {
-                // already registered
-                return;
-            } else {
-                throw new GroovyRuntimeException("Conflicting module versions. Module [" + module.getName() + " is loaded in version " +
-                        loadedModule.getVersion() + " and you are trying to load version " + module.getVersion());
-            }
-        }
+        // Caller already removed any pre-existing module with the same name.
         moduleRegistry.addModule(module);
         // register MetaMethods
         List<MetaMethod> metaMethods = module.getMetaMethods();

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleServiceIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleServiceIT.java
@@ -175,6 +175,54 @@ class GroovyConsoleServiceIT {
         assertEquals("{\"a\":1}", response.get("result").getAsString());
     }
 
+    @Test
+    void testDateutilFragmentExtensions() throws Exception {
+        // Date.format(String, TimeZone) and Calendar.format(String) are extension methods
+        // contributed by groovy-dateutil, which ships as a fragment in Groovy 4.0.23+.
+        // groovy-osgi must register these against the runtime MetaClassRegistry or every
+        // call site that uses them will fail with MissingMethodException.
+        JsonObject response = executeScript(
+                "def date = new Date(0)\n" +
+                "def gmt = TimeZone.getTimeZone('GMT')\n" +
+                "return date.format('yyyy-MM-dd', gmt)"
+        );
+
+        assertNotNull(response, "Could not get response from API");
+        assertEquals("", response.get("exceptionStackTrace").getAsString(),
+                "Date.format should be available; groovy-dateutil fragment extensions not registered");
+        assertEquals("1970-01-01", response.get("result").getAsString());
+    }
+
+    @Test
+    void testJsonFragmentExtensions() throws Exception {
+        // toJson() / parseJson() ship in groovy-json (fragment in 4.0.23+).
+        JsonObject response = executeScript(
+                "import groovy.json.JsonOutput\n" +
+                "import groovy.json.JsonSlurper\n" +
+                "def json = JsonOutput.toJson([a: 1, b: [2, 3]])\n" +
+                "return new JsonSlurper().parseText(json)"
+        );
+
+        assertNotNull(response, "Could not get response from API");
+        assertEquals("", response.get("exceptionStackTrace").getAsString(),
+                "groovy-json fragment extensions not registered");
+        assertEquals("[a:1, b:[2, 3]]", response.get("result").getAsString());
+    }
+
+    @Test
+    void testXmlFragmentExtensions() throws Exception {
+        // XmlSlurper / XmlParser ship in groovy-xml (fragment in 4.0.23+).
+        JsonObject response = executeScript(
+                "def xml = new groovy.xml.XmlSlurper().parseText('<root><a>1</a></root>')\n" +
+                "return xml.a.text()"
+        );
+
+        assertNotNull(response, "Could not get response from API");
+        assertEquals("", response.get("exceptionStackTrace").getAsString(),
+                "groovy-xml fragment extensions not registered");
+        assertEquals("1", response.get("result").getAsString());
+    }
+
     private static boolean isHealthy() {
         try {
             HttpGet healthCheck = new HttpGet(BASE_URL + "/system/health.json?tags=systemalive,groovyconsole");

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <!-- Versions -->
         <bnd.version>6.4.0</bnd.version>
         <aem.version>6.5.10</aem.version>
-        <groovy.version>4.0.22</groovy.version>
+        <groovy.version>4.0.31</groovy.version>
         <asm.version>9.7</asm.version>
         <njord.version>0.9.4</njord.version>
 
@@ -145,6 +145,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -180,10 +184,6 @@
                         <version>3.0.8-01</version>
                     </dependency>
                 </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
             </plugin>
         </plugins>
 
@@ -335,7 +335,7 @@
                 <plugin>
                     <groupId>com.adobe.aem</groupId>
                     <artifactId>aemanalyser-maven-plugin</artifactId>
-                    <version>1.5.8</version>
+                    <version>1.6.18</version>
                     <extensions>true</extensions>
                     <configuration>
                         <skip>${aemanalyser.skip.validation}</skip>


### PR DESCRIPTION
- Bump groovy.version 4.0.22 -> 4.0.31
- Add GroovyBundleToFragmentFixer to work around SLING-13123 on AEM 6.5 on-prem and Sling Starter (skipped on AEMaaCS via cloud runmode check). Self-disables when installer-core >= 3.14.6 is detected.
- Bump aemanalyser-maven-plugin 1.5.8 -> 1.6.18
- Move maven-gpg-plugin to the release profile so local builds don't require a GPG key