### PR TITLE
Upgrade Groovy to 5.0.5 (Java 11+ required)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Upgrade Groovy from 4.0.31 to 5.0.5
+- **BREAKING:** Upgrade Groovy from 4.0.31 to 5.0.6
 - **BREAKING:** Drop Java 8 support — minimum is now Java 11 (Groovy 5.x requires JDK 11+)
 - Bump exported API package versions to 20.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Upgrade Groovy from 4.0.31 to 5.0.5
+- **BREAKING:** Drop Java 8 support — minimum is now Java 11 (Groovy 5.x requires JDK 11+)
+- Bump exported API package versions to 20.0.0
+
 ## [19.1.0] - 2026-05-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ in the package for reference.
 
 ## Compatibility
 
-AEM Groovy Console 19.0.8+ runs on Java 8, 11, 17 & 21 with an embedded Groovy version of 4.0.22
+AEM Groovy Console 20.x requires **Java 11, 17 or 21** with an embedded Groovy version of 5.0.5.
+
+For environments still on Java 8, use AEM Groovy Console 19.x (last release on the Groovy 4.x line).
 
 Supported versions:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ in the package for reference.
 
 ## Compatibility
 
-AEM Groovy Console 20.x requires **Java 11, 17 or 21** with an embedded Groovy version of 5.0.5.
+AEM Groovy Console 20.x requires **Java 11, 17 or 21** with an embedded Groovy version of 5.0.6.
 
 For environments still on Java 8, use AEM Groovy Console 19.x (last release on the Groovy 4.x line).
 

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>be.orbinson.aem</groupId>
         <artifactId>aem-groovy-console</artifactId>
-        <version>19.1.1-SNAPSHOT</version>
+        <version>20.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aem-groovy-console-all</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>be.orbinson.aem</groupId>
         <artifactId>aem-groovy-console</artifactId>
-        <version>19.1.1-SNAPSHOT</version>
+        <version>20.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aem-groovy-console-api</artifactId>

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/context/impl/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/context/impl/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.api.context.impl;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/context/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/context/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.api.context;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.api;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/audit/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/audit/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.1.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.audit;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/configuration/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/configuration/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.configuration;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/constants/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/constants/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.1")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.constants;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/extension/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/extension/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.extension;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/notification/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/notification/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.notification;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/response/impl/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/response/impl/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.response.impl;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/response/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/response/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.response;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/table/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/table/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.table;

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/utils/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/utils/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.utils;

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>be.orbinson.aem</groupId>
         <artifactId>aem-groovy-console</artifactId>
-        <version>19.1.1-SNAPSHOT</version>
+        <version>20.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aem-groovy-console-bundle</artifactId>

--- a/bundle/src/main/groovy/be/orbinson/aem/groovy/console/components/package-info.groovy
+++ b/bundle/src/main/groovy/be/orbinson/aem/groovy/console/components/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("19.0.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.components;

--- a/groovy/groovy-osgi/pom.xml
+++ b/groovy/groovy-osgi/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>be.orbinson.aem</groupId>
         <artifactId>aem-groovy-console</artifactId>
-        <version>19.1.1-SNAPSHOT</version>
+        <version>20.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>be.orbinson.aem</groupId>
         <artifactId>aem-groovy-console</artifactId>
-        <version>19.1.1-SNAPSHOT</version>
+        <version>20.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/it.tests/pom.xml
+++ b/it.tests/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>be.orbinson.aem</groupId>
         <artifactId>aem-groovy-console</artifactId>
-        <version>19.1.1-SNAPSHOT</version>
+        <version>20.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aem-groovy-console-it-tests</artifactId>

--- a/it.tests/pom.xml
+++ b/it.tests/pom.xml
@@ -86,6 +86,11 @@
                                                 <version>14</version>
                                             </includeArtifact>
                                             <filesInclude>*.json</filesInclude>
+                                            <!-- WORKAROUND: Starter 14 ships jetty12 1.1.8; jetty12.json pins 1.2.0,
+                                                 take the highest. Remove once we move to Sling Starter 15. -->
+                                            <artifactsOverrides>
+                                                <artifactsOverride>org.apache.felix:org.apache.felix.http.jetty12:HIGHEST</artifactsOverride>
+                                            </artifactsOverrides>
                                         </aggregate>
                                     </aggregates>
                                     <replacePropertyVariables>project.version</replacePropertyVariables>

--- a/it.tests/src/main/features/jetty12.json
+++ b/it.tests/src/main/features/jetty12.json
@@ -1,0 +1,11 @@
+{
+  // WORKAROUND: Sling Starter 14 ships org.apache.felix.http.jetty12 1.1.8, which
+  // intermittently fails IT startup. Pin 1.2.0 here (the aggregate's artifactsOverrides
+  // takes HIGHEST). Remove this file and the override once we move to Sling Starter 15.
+  "bundles": [
+    {
+      "id": "org.apache.felix:org.apache.felix.http.jetty12:1.2.0",
+      "start-order": "5"
+    }
+  ]
+}

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleServiceIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleServiceIT.java
@@ -20,9 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
 
 class GroovyConsoleServiceIT {
@@ -36,11 +34,60 @@ class GroovyConsoleServiceIT {
     @BeforeAll
     static void setUp() {
         httpClient = HttpClients.createDefault();
+        waitForStableReadiness(300, 15);
+    }
 
-        // Wait for the Sling Starter and the Groovy Console content package to be fully installed
-        await().atMost(120, TimeUnit.SECONDS)
-                .pollInterval(5, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertTrue(isHealthy(), "System not healthy"));
+    /**
+     * Polls the Groovy Console servlet with a no-op script until it has returned 200 OK for a
+     * continuous window. This guards against the Sling Starter package-install refresh cascade
+     * that briefly tears down our bundle: a single OK isn't enough — we need stability before
+     * the test cases start firing requests.
+     */
+    private static void waitForStableReadiness(long overallTimeoutSec, long stabilityWindowSec) {
+        long deadline = System.currentTimeMillis() + overallTimeoutSec * 1000;
+        long stableSince = -1;
+        while (System.currentTimeMillis() < deadline) {
+            boolean ready = isGroovyConsoleReady();
+            long now = System.currentTimeMillis();
+            if (ready) {
+                if (stableSince < 0) {
+                    stableSince = now;
+                } else if (now - stableSince >= stabilityWindowSec * 1000) {
+                    return;
+                }
+            } else {
+                stableSince = -1;
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail("Interrupted while waiting for Groovy Console readiness");
+            }
+        }
+        fail("Groovy Console did not become stable within " + overallTimeoutSec
+                + "s (need " + stabilityWindowSec + "s of continuous OK)");
+    }
+
+    private static boolean isGroovyConsoleReady() {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpPost post = new HttpPost(BASE_URL + "/bin/groovyconsole/post");
+            List<BasicNameValuePair> params = new ArrayList<>();
+            params.add(new BasicNameValuePair("script", "return 'ready'"));
+            post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+            post.addHeader("Authorization", AUTH_HEADER);
+            post.addHeader("Connection", "close");
+            try (CloseableHttpResponse response = client.execute(post)) {
+                if (response.getStatusLine().getStatusCode() != 200) {
+                    return false;
+                }
+                String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                JsonObject json = JsonParser.parseString(body).getAsJsonObject();
+                return "ready".equals(json.get("result").getAsString());
+            }
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     @AfterAll
@@ -221,20 +268,6 @@ class GroovyConsoleServiceIT {
         assertEquals("", response.get("exceptionStackTrace").getAsString(),
                 "groovy-xml fragment extensions not registered");
         assertEquals("1", response.get("result").getAsString());
-    }
-
-    private static boolean isHealthy() {
-        try {
-            HttpGet healthCheck = new HttpGet(BASE_URL + "/system/health.json?tags=systemalive,groovyconsole");
-            healthCheck.addHeader("Authorization", AUTH_HEADER);
-            try (CloseableHttpResponse response = httpClient.execute(healthCheck)) {
-                String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-                JsonObject jsonResponse = JsonParser.parseString(body).getAsJsonObject();
-                return "OK".equals(jsonResponse.get("overallResult").getAsString());
-            }
-        } catch (Exception e) {
-            return false;
-        }
     }
 
     private static JsonObject doGet(String path) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <!-- Versions -->
         <bnd.version>6.4.0</bnd.version>
         <aem.version>6.5.10</aem.version>
-        <groovy.version>5.0.5</groovy.version>
+        <groovy.version>5.0.6</groovy.version>
         <asm.version>9.9.1</asm.version>
         <njord.version>0.9.4</njord.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>be.orbinson.aem</groupId>
     <artifactId>aem-groovy-console</artifactId>
     <packaging>pom</packaging>
-    <version>19.1.1-SNAPSHOT</version>
+    <version>20.0.0-SNAPSHOT</version>
 
     <name>AEM Groovy Console</name>
     <description>
@@ -84,8 +84,8 @@
     <properties>
         <!-- Maven -->
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss.SSSZ</maven.build.timestamp.format>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <timestamp>${maven.build.timestamp}</timestamp>
@@ -93,7 +93,7 @@
         <!-- Versions -->
         <bnd.version>6.4.0</bnd.version>
         <aem.version>6.5.10</aem.version>
-        <groovy.version>4.0.31</groovy.version>
+        <groovy.version>5.0.5</groovy.version>
         <asm.version>9.7</asm.version>
         <njord.version>0.9.4</njord.version>
 
@@ -168,8 +168,8 @@
                 <version>3.8.1</version>
                 <configuration>
                     <compilerId>groovy-eclipse-compiler</compilerId>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                     <encoding>utf-8</encoding>
                 </configuration>
                 <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <bnd.version>6.4.0</bnd.version>
         <aem.version>6.5.10</aem.version>
         <groovy.version>5.0.5</groovy.version>
-        <asm.version>9.7</asm.version>
+        <asm.version>9.9.1</asm.version>
         <njord.version>0.9.4</njord.version>
 
         <!-- SonarCloud -->

--- a/ui.apps.aem/pom.xml
+++ b/ui.apps.aem/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>be.orbinson.aem</groupId>
         <artifactId>aem-groovy-console</artifactId>
-        <version>19.1.1-SNAPSHOT</version>
+        <version>20.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aem-groovy-console-ui.apps.aem</artifactId>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>be.orbinson.aem</groupId>
         <artifactId>aem-groovy-console</artifactId>
-        <version>19.1.1-SNAPSHOT</version>
+        <version>20.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aem-groovy-console-ui.apps</artifactId>

--- a/ui.config/pom.xml
+++ b/ui.config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>be.orbinson.aem</groupId>
         <artifactId>aem-groovy-console</artifactId>
-        <version>19.1.1-SNAPSHOT</version>
+        <version>20.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aem-groovy-console-ui.config</artifactId>

--- a/ui.config/src/main/content/jcr_root/apps/groovyconsole-config/osgiconfig/config/org.apache.felix.hc.generalchecks.ServicesCheck-groovyconsole.config
+++ b/ui.config/src/main/content/jcr_root/apps/groovyconsole-config/osgiconfig/config/org.apache.felix.hc.generalchecks.ServicesCheck-groovyconsole.config
@@ -1,3 +1,0 @@
-hc.name="Groovy Console Services"
-hc.tags=["groovyconsole"]
-services.list=["be.orbinson.aem.groovy.console.GroovyConsoleService"]

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>be.orbinson.aem</groupId>
         <artifactId>aem-groovy-console</artifactId>
-        <version>19.1.1-SNAPSHOT</version>
+        <version>20.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>aem-groovy-console-ui.content</artifactId>


### PR DESCRIPTION
- Bump groovy.version 4.0.31 -> 5.0.5
- Raise maven.compiler.source/target from 1.8 to 11 (Groovy 5 requires JDK 11+)
- Bump exported API package versions to 20.0.0 to satisfy bnd-baseline
- Update README compatibility section: 20.x requires Java 11/17/21, 19.x remains the line for Java 8 environments
- Bump project version to 20.0.0-SNAPSHOT