### PR TITLE
Add test-support module for unit-testing Groovy Console scripts

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -156,7 +156,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bundle/src/main/groovy/be/orbinson/aem/groovy/console/builders/AbstractContentBuilder.groovy
+++ b/bundle/src/main/groovy/be/orbinson/aem/groovy/console/builders/AbstractContentBuilder.groovy
@@ -10,18 +10,41 @@ abstract class AbstractContentBuilder extends BuilderSupport {
 
     Session session
 
-    Node currentNode
+    // Backing field for the currentNode property. Named distinctly so that subclass access to "currentNode" always
+    // routes through getCurrentNode()/setCurrentNode() rather than the field, keeping root resolution lazy.
+    private Node resolvedNode
+
+    // Resolves the root node on first use, so constructing a builder does not require a live JCR session.
+    private Closure<Node> rootNodeResolver
 
     AbstractContentBuilder(Session session, Node currentNode) {
         this.session = session
-        this.currentNode = currentNode
+        this.resolvedNode = currentNode
+    }
+
+    AbstractContentBuilder(Session session, Closure<Node> rootNodeResolver) {
+        this.session = session
+        this.rootNodeResolver = rootNodeResolver
+    }
+
+    Node getCurrentNode() {
+        if (resolvedNode == null && rootNodeResolver != null) {
+            resolvedNode = rootNodeResolver.call()
+            rootNodeResolver = null
+        }
+
+        resolvedNode
+    }
+
+    void setCurrentNode(Node currentNode) {
+        this.resolvedNode = currentNode
     }
 
     @Override
     void nodeCompleted(parent, node) {
         session.save()
 
-        currentNode = currentNode.parent
+        resolvedNode = getCurrentNode().parent
     }
 
     @Override

--- a/bundle/src/main/groovy/be/orbinson/aem/groovy/console/builders/NodeBuilder.groovy
+++ b/bundle/src/main/groovy/be/orbinson/aem/groovy/console/builders/NodeBuilder.groovy
@@ -27,7 +27,7 @@ import javax.jcr.Session
 class NodeBuilder extends AbstractContentBuilder {
 
     NodeBuilder(Session session) {
-        super(session, session.rootNode)
+        super(session, { session.rootNode } as Closure<Node>)
     }
 
     NodeBuilder(Session session, Node rootNode) {

--- a/bundle/src/main/groovy/be/orbinson/aem/groovy/console/builders/PageBuilder.groovy
+++ b/bundle/src/main/groovy/be/orbinson/aem/groovy/console/builders/PageBuilder.groovy
@@ -41,7 +41,7 @@ class PageBuilder extends AbstractContentBuilder {
     private static final String NT_PAGE_CONTENT = "cq:PageContent"
 
     PageBuilder(Session session) {
-        super(session, session.rootNode)
+        super(session, { session.rootNode } as Closure<Node>)
     }
 
     PageBuilder(Session session, Page rootPage) {

--- a/bundle/src/main/groovy/be/orbinson/aem/groovy/console/extension/impl/binding/AemBindingExtensionProvider.groovy
+++ b/bundle/src/main/groovy/be/orbinson/aem/groovy/console/extension/impl/binding/AemBindingExtensionProvider.groovy
@@ -4,8 +4,8 @@ import be.orbinson.aem.groovy.console.api.BindingExtensionProvider
 import be.orbinson.aem.groovy.console.api.BindingVariable
 import be.orbinson.aem.groovy.console.api.context.ScriptContext
 import be.orbinson.aem.groovy.console.builders.PageBuilder
-import com.day.cq.search.QueryBuilder
 import com.day.cq.wcm.api.PageManager
+import com.day.cq.wcm.api.PageManagerFactory
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 
@@ -14,8 +14,9 @@ import javax.jcr.Session
 @Component(service = BindingExtensionProvider, immediate = true)
 class AemBindingExtensionProvider implements BindingExtensionProvider {
 
+    // Reference to make sure that this class does not become active when running in Sling instead of AEM
     @Reference
-    private QueryBuilder queryBuilder
+    private PageManagerFactory pageManagerFactory
 
     @Override
     Map<String, BindingVariable> getBindingVariables(ScriptContext scriptContext) {

--- a/bundle/src/main/groovy/be/orbinson/aem/groovy/console/extension/impl/scriptmetaclass/AemScriptMetaClassExtensionProvider.groovy
+++ b/bundle/src/main/groovy/be/orbinson/aem/groovy/console/extension/impl/scriptmetaclass/AemScriptMetaClassExtensionProvider.groovy
@@ -8,25 +8,31 @@ import com.day.cq.replication.Replicator
 import com.day.cq.search.PredicateGroup
 import com.day.cq.search.QueryBuilder
 import com.day.cq.wcm.api.PageManager
+import com.day.cq.wcm.api.PageManagerFactory
 import org.apache.sling.distribution.DistributionRequest
-import org.apache.sling.distribution.Distributor
 import org.apache.sling.distribution.DistributionRequestType
+import org.apache.sling.distribution.Distributor
 import org.apache.sling.distribution.SimpleDistributionRequest
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceCardinality
 
 import javax.jcr.Session
 
 @Component(service = ScriptMetaClassExtensionProvider, immediate = true)
 class AemScriptMetaClassExtensionProvider implements ScriptMetaClassExtensionProvider {
 
+    // Reference to make sure that this class does not become active when running in Sling instead of AEM
     @Reference
+    private PageManagerFactory pageManagerFactory
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
     private Replicator replicator
 
-    @Reference
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
     private QueryBuilder queryBuilder
 
-    @Reference
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
     private Distributor distributor;
 
     @Override
@@ -42,29 +48,29 @@ class AemScriptMetaClassExtensionProvider implements ScriptMetaClassExtensionPro
             }
 
             delegate.activate = { String path, ReplicationOptions options = null ->
-                replicator.replicate(session, ReplicationActionType.ACTIVATE, path, options)
+                requireReplicator().replicate(session, ReplicationActionType.ACTIVATE, path, options)
             }
 
             delegate.deactivate = { String path, ReplicationOptions options = null ->
-                replicator.replicate(session, ReplicationActionType.DEACTIVATE, path, options)
+                requireReplicator().replicate(session, ReplicationActionType.DEACTIVATE, path, options)
             }
 
             delegate.delete { String path, ReplicationOptions options = null ->
-                replicator.replicate(session, ReplicationActionType.DELETE, path, options)
+                requireReplicator().replicate(session, ReplicationActionType.DELETE, path, options)
             }
 
             delegate.distribute { String path, String agentId = "publish", boolean isDeep = false ->
                 DistributionRequest distributionRequest = new SimpleDistributionRequest(DistributionRequestType.ADD, isDeep, path);
-                distributor.distribute(agentId, resourceResolver, distributionRequest);
+                requireDistributor().distribute(agentId, resourceResolver, distributionRequest);
             }
 
             delegate.invalidate { String path, String agentId = "publish", boolean isDeep = false ->
                 DistributionRequest distributionRequest = new SimpleDistributionRequest(DistributionRequestType.INVALIDATE, isDeep, path);
-                distributor.distribute(agentId, resourceResolver, distributionRequest);
+                requireDistributor().distribute(agentId, resourceResolver, distributionRequest);
             }
 
             delegate.createQuery { Map predicates ->
-                queryBuilder.createQuery(PredicateGroup.create(predicates), session)
+                requireQueryBuilder().createQuery(PredicateGroup.create(predicates), session)
             }
 
         }
@@ -72,4 +78,26 @@ class AemScriptMetaClassExtensionProvider implements ScriptMetaClassExtensionPro
         closure
     }
 
+    private Replicator requireReplicator() {
+        if (replicator == null) {
+            throw new IllegalStateException("No Replicator service available: activate/deactivate/delete require AEM's replication API.")
+        }
+        replicator
+    }
+
+    private QueryBuilder requireQueryBuilder() {
+        if (queryBuilder == null) {
+            throw new IllegalStateException("No QueryBuilder service available: createQuery requires AEM's query API.")
+        }
+        queryBuilder
+    }
+
+    private Distributor requireDistributor() {
+        if (distributor == null) {
+            throw new IllegalStateException("No Distributor service available: distribute/invalidate require Sling Content Distribution.")
+        }
+        distributor
+    }
+
 }
+

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>all</module>
         <module>api</module>
         <module>bundle</module>
+        <module>test-support</module>
         <module>groovy</module>
         <module>ui.frontend</module>
         <module>ui.apps</module>
@@ -238,7 +239,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>3.5.2</version>
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
                         <useSystemClassLoader>false</useSystemClassLoader>
@@ -620,32 +621,44 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.8.2</version>
+                <version>5.11.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>4.1.0</version>
+                <artifactId>mockito-core</artifactId>
+                <version>5.21.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
-                <version>4.1.0</version>
+                <version>5.21.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-                <version>5.1.2</version>
+                <version>5.7.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
-                <version>3.1.4-1.40.0</version>
+                <version>4.1.0-1.86.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
+                <version>3.6.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.event.api</artifactId>
+                <version>1.0.0</version>
                 <scope>test</scope>
             </dependency>
 

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>be.orbinson.aem</groupId>
+        <artifactId>aem-groovy-console</artifactId>
+        <version>20.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>aem-groovy-console-test-support</artifactId>
+    <name>AEM Groovy Console - Test Support</name>
+    <description>
+        Reusable JUnit 5 / Sling Mocks harness for unit-testing Groovy Console scripts. Downstream projects add this
+        single artifact at test scope and get a configured console (bindings, metaclasses, script metaclasses) that
+        can execute a script string against a {@code SlingContext}. AEM-only script features light up automatically
+        when the consumer also uses wcm.io's {@code AemContext})
+    </description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive combine.self="override"/>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- Console modules under test. These transitively pull the Groovy runtime. -->
+        <dependency>
+            <groupId>be.orbinson.aem</groupId>
+            <artifactId>aem-groovy-console-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>be.orbinson.aem</groupId>
+            <artifactId>aem-groovy-console-bundle</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.event.api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Test tooling -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-support/src/main/java/be/orbinson/aem/groovy/console/testing/ContextPlugins.java
+++ b/test-support/src/main/java/be/orbinson/aem/groovy/console/testing/ContextPlugins.java
@@ -1,0 +1,130 @@
+package be.orbinson.aem.groovy.console.testing;
+
+import be.orbinson.aem.groovy.console.audit.AuditService;
+import be.orbinson.aem.groovy.console.configuration.ConfigurationService;
+import be.orbinson.aem.groovy.console.extension.impl.DefaultExtensionService;
+import be.orbinson.aem.groovy.console.extension.impl.binding.AemBindingExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.binding.JcrBindingExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.binding.SlingBindingExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.metaclass.AemMetaClassExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.metaclass.JcrMetaClassExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.metaclass.SlingMetaClassExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.scriptmetaclass.AemScriptMetaClassExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.scriptmetaclass.JcrScriptMetaClassExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.scriptmetaclass.OsgiScriptMetaClassExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.scriptmetaclass.SlingScriptMetaClassExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.startimport.AemStarImportExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.startimport.JcrStarImportExtensionProvider;
+import be.orbinson.aem.groovy.console.extension.impl.startimport.SlingStarImportExtensionProvider;
+import be.orbinson.aem.groovy.console.impl.DefaultGroovyConsoleService;
+import be.orbinson.aem.groovy.console.impl.GroovyShellFactory;
+import org.apache.sling.event.jobs.JobManager;
+import org.apache.sling.testing.mock.osgi.ReferenceViolationException;
+import org.apache.sling.testing.mock.osgi.context.AbstractContextPlugin;
+import org.apache.sling.testing.mock.osgi.context.ContextPlugin;
+import org.apache.sling.testing.mock.osgi.context.OsgiContextImpl;
+
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Sling/AEM Mocks {@link ContextPlugin}s for unit-testing AEM Groovy Console scripts.
+ * <p>
+ * Add {@link #GROOVY_CONSOLE} to a {@code SlingContextBuilder} (or {@code AemContextBuilder}, which extends it) to
+ * wire up the same default extension stack the console uses at runtime — bindings ({@code resourceResolver},
+ * {@code session}, ...), script metaclasses ({@code getNode}, {@code save}, ...) and type metaclasses
+ * ({@code Node#get}/{@code set}, ...). Scripts can then be executed with {@link GroovyConsole#runScript}.
+ * <p>
+ * The console's core service requires {@link JobManager}, {@link ConfigurationService} and {@link AuditService};
+ * this plugin auto-mocks those three when absent so the console always starts. AEM-only OSGi service such as
+ * {@code QueryBuilder}, {@code Replicator}, {@code Distributor} and {@code PageManagerFactory} are <em>not</em>
+ * mocked automatically. Register the AEM OSGi service(s) you need (real or mocked) before this plugin runs,
+ * and add wcm.io's {@code AemContext}/uber-jar yourself, to opt into the AEM-only behaviour:
+ * <pre>
+ * &#64;ExtendWith(AemContextExtension.class)
+ * class MyScriptsTest {
+ *
+ *     private final QueryBuilder queryBuilder = mock(QueryBuilder.class);
+ *
+ *     private final AemContext context = new AemContextBuilder()
+ *             .beforeSetUp(ctx -> ctx.registerService(QueryBuilder.class, queryBuilder))
+ *             .plugin(ContextPlugins.GROOVY_CONSOLE)
+ *             .build();
+ *
+ *     &#64;Test
+ *     void runsMyScript() {
+ *         context.create().page("/content/site");
+ *         RunScriptResponse response = GroovyConsole.runScript(context, "println createQuery([path: '/content/site']).result.hits.size()");
+ *         assertTrue(response.getExceptionStackTrace().isEmpty());
+ *     }
+ * }
+ * </pre>
+ */
+public final class ContextPlugins {
+
+    public static final ContextPlugin<OsgiContextImpl> GROOVY_CONSOLE = new AbstractContextPlugin<OsgiContextImpl>() {
+        @Override
+        public void afterSetUp(OsgiContextImpl context) {
+            registerConsole(context);
+        }
+    };
+
+    private ContextPlugins() {
+        // constants only
+    }
+
+    private static void registerConsole(OsgiContextImpl context) {
+        // OSGi Services the console's core service requires to activate at all. Only stubbed when the consumer has
+        // not already registered their own, so they remain overridable.
+        registerMockIfAbsent(context, JobManager.class);
+        registerMockIfAbsent(context, ConfigurationService.class);
+        registerMockIfAbsent(context, AuditService.class);
+
+        context.registerInjectActivateService(new DefaultExtensionService());
+
+        // Bindings: resourceResolver, session, nodeBuilder, log, out, ...
+        context.registerInjectActivateService(new SlingBindingExtensionProvider());
+        context.registerInjectActivateService(new JcrBindingExtensionProvider());
+
+        // Script metaclass methods: getResource/getModel/table, getNode/save/move, getService(s), ...
+        context.registerInjectActivateService(new SlingScriptMetaClassExtensionProvider());
+        context.registerInjectActivateService(new JcrScriptMetaClassExtensionProvider());
+        context.registerInjectActivateService(new OsgiScriptMetaClassExtensionProvider());
+
+        // Type metaclasses: Node#get/set/recurse, ...
+        context.registerInjectActivateService(new SlingMetaClassExtensionProvider());
+        context.registerInjectActivateService(new JcrMetaClassExtensionProvider());
+
+        // Star imports so scripts can use unqualified Sling/JCR class names.
+        context.registerInjectActivateService(new SlingStarImportExtensionProvider());
+        context.registerInjectActivateService(new JcrStarImportExtensionProvider());
+        context.registerInjectActivateService(new AemStarImportExtensionProvider());
+
+        // AEM-only providers reference services (QueryBuilder, Replicator, Distributor, PageManagerFactory)
+        // that only exist when AEM is present.
+        registerIfSatisfied(context, AemBindingExtensionProvider::new);
+        registerIfSatisfied(context, AemScriptMetaClassExtensionProvider::new);
+        registerIfSatisfied(context, AemMetaClassExtensionProvider::new);
+
+        context.registerInjectActivateService(new GroovyShellFactory());
+        context.registerInjectActivateService(new DefaultGroovyConsoleService());
+    }
+
+    private static <T> void registerMockIfAbsent(OsgiContextImpl context, Class<T> type) {
+        if (context.getService(type) == null) {
+            context.registerService(type, mock(type));
+        }
+    }
+
+    private static void registerIfSatisfied(OsgiContextImpl context, Supplier<Object> serviceFactory) {
+        try {
+            context.registerInjectActivateService(serviceFactory.get());
+        } catch (ReferenceViolationException ignored) {
+            // one of the service's mandatory AEM OSGi services is not registered on this context
+        } catch (LinkageError ignored) {
+            // AEM classes referenced by the service's fields (e.g. QueryBuilder, Replicator, PageManagerFactory)
+            // are not on the classpath (no AEM/uber-jar dependency)
+        }
+    }
+}

--- a/test-support/src/main/java/be/orbinson/aem/groovy/console/testing/GroovyConsole.java
+++ b/test-support/src/main/java/be/orbinson/aem/groovy/console/testing/GroovyConsole.java
@@ -1,0 +1,58 @@
+package be.orbinson.aem.groovy.console.testing;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.sling.testing.mock.sling.context.SlingContextImpl;
+
+import be.orbinson.aem.groovy.console.GroovyConsoleService;
+import be.orbinson.aem.groovy.console.api.context.impl.RequestScriptContext;
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+
+/**
+ * Convenience for executing a Groovy Console script against a context with a {@link GroovyConsoleService} registered
+ */
+public final class GroovyConsole {
+
+    private GroovyConsole() {
+    }
+
+    /**
+     * Execute a script against the given context and return the response (output, result, exception stack trace,
+     * running time). The context must have a {@link GroovyConsoleService} registered, for example by building it
+     * with {@link ContextPlugins#GROOVY_CONSOLE}.
+     *
+     * @param context the Sling/AEM mock context (e.g. an {@code AemContext})
+     * @param script  the Groovy script source to run
+     * @return the run response
+     */
+    public static RunScriptResponse runScript(SlingContextImpl context, String script) {
+        GroovyConsoleService service = context.getService(GroovyConsoleService.class);
+
+        if (service == null) {
+            throw new IllegalStateException("GroovyConsoleService is not registered. Add ContextPlugins.GROOVY_CONSOLE "
+                    + "to your AemContextBuilder (and use ResourceResolverType.JCR_MOCK for scripts that touch the JCR).");
+        }
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        RequestScriptContext scriptContext = new RequestScriptContext(
+                context.request(),
+                context.response(),
+                outputStream,
+                printStream(outputStream),
+                script);
+
+        return service.runScript(scriptContext);
+    }
+
+    private static PrintStream printStream(ByteArrayOutputStream outputStream) {
+        try {
+            return new PrintStream(outputStream, true, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/test-support/src/test/java/be/orbinson/aem/groovy/console/testing/ContextPluginsTest.java
+++ b/test-support/src/test/java/be/orbinson/aem/groovy/console/testing/ContextPluginsTest.java
@@ -1,0 +1,35 @@
+package be.orbinson.aem.groovy.console.testing;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextBuilder;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test that uses {@link ContextPlugins#GROOVY_CONSOLE} on a plain {@code SlingContext}.
+ * This module has no AEM/uber-jar dependency to showcase that everything works without the uber-jar dependency.
+ */
+@ExtendWith(SlingContextExtension.class)
+class ContextPluginsTest {
+
+    private final SlingContext context = new SlingContextBuilder()
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void runsAnInlineScriptAndCapturesOutput() {
+        context.create().resource("/content/site", "jcr:title", "Site");
+
+        RunScriptResponse response = GroovyConsole.runScript(context,
+                "println resourceResolver.getResource('/content/site').getValueMap().get('jcr:title')");
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+        assertEquals("Site\n", response.getOutput());
+    }
+
+}

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -66,6 +66,19 @@
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>
         </dependency>
+
+        <!-- Unit-test the shipped Groovy scripts -->
+        <dependency>
+            <groupId>io.wcm</groupId>
+            <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>be.orbinson.aem</groupId>
+            <artifactId>aem-groovy-console-test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/ui.content/src/main/content/jcr_root/conf/groovyconsole/scripts/samples/CreateOsgiConfigurations.groovy
+++ b/ui.content/src/main/content/jcr_root/conf/groovyconsole/scripts/samples/CreateOsgiConfigurations.groovy
@@ -2,14 +2,13 @@ import org.osgi.service.cm.ConfigurationAdmin
 
 def loggers = [
     "com.day.cq.dam": "dam",
-    "be.orbinson..aem.groovy.console": "groovyconsole"
+    "be.orbinson.aem.groovy.console": "groovyconsole"
 ]
 
 def admin = getService(ConfigurationAdmin)
 
 loggers.each { loggerName, fileName ->
-    def config = admin.createFactoryConfiguration("org.apache.sling.commons.log.LogManager.factory.config",
-        "slinginstall:org.apache.sling.commons.log-5.0.0.jar")
+    def config = admin.getFactoryConfiguration("org.apache.sling.commons.log.LogManager.factory.config", fileName)
 
     def properties = [
         "org.apache.sling.commons.log.level": "debug",

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/CreateOsgiConfigurationsTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/CreateOsgiConfigurationsTest.java
@@ -1,0 +1,43 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@code CreateOsgiConfigurations.groovy} sample: creates a logger factory configuration per entry.
+ */
+@ExtendWith(AemContextExtension.class)
+class CreateOsgiConfigurationsTest {
+
+    private static final String FACTORY_PID = "org.apache.sling.commons.log.LogManager.factory.config";
+
+    private final AemContext context = new AemContextBuilder()
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void createsAFactoryConfigurationPerLogger() throws Exception {
+        ConfigurationAdmin configurationAdmin = context.getService(ConfigurationAdmin.class);
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("CreateOsgiConfigurations.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+
+        assertEquals("com.day.cq.dam",
+                configurationAdmin.getFactoryConfiguration(FACTORY_PID, "dam")
+                        .getProperties().get("org.apache.sling.commons.log.names"));
+        assertEquals("be.orbinson.aem.groovy.console",
+                configurationAdmin.getFactoryConfiguration(FACTORY_PID, "groovyconsole")
+                        .getProperties().get("org.apache.sling.commons.log.names"));
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/CreatePackageTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/CreatePackageTest.java
@@ -1,0 +1,36 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@code CreatePackage.groovy} sample: builds a FileVault package definition node under /etc/packages.
+ */
+@ExtendWith(AemContextExtension.class)
+class CreatePackageTest {
+
+    private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK)
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void createsPackageDefinition() {
+        context.create().resource("/etc/packages", "jcr:primaryType", "sling:Folder");
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("CreatePackage.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+        assertNotNull(context.resourceResolver()
+                .getResource("/etc/packages/groovy-console-history.zip/jcr:content/vlt:definition/filter/filter0"), "expected the filter node to be created");
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/DeleteOsgiConfigurationsTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/DeleteOsgiConfigurationsTest.java
@@ -1,0 +1,49 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the {@code DeleteOsgiConfigurations.groovy} sample
+ */
+@ExtendWith(AemContextExtension.class)
+class DeleteOsgiConfigurationsTest {
+
+    private static final String FACTORY_PID = "com.day.cq.compat.migration.factory.location";
+
+    private static final String FILTER = "(service.factoryPid=" + FACTORY_PID + ")";
+
+    private final AemContext context = new AemContextBuilder()
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void deletesConfigurationsMatchingTheFactoryPid() throws Exception {
+        ConfigurationAdmin configurationAdmin = context.getService(ConfigurationAdmin.class);
+
+        Configuration configuration = configurationAdmin.getFactoryConfiguration(FACTORY_PID, "location-1");
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put("location", "/content");
+        configuration.update(properties);
+
+        assertEquals(1, configurationAdmin.listConfigurations(FILTER).length);
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("DeleteOsgiConfigurations.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+        assertNull(configurationAdmin.listConfigurations(FILTER));
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/FindOrphanedComponentsTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/FindOrphanedComponentsTest.java
@@ -1,0 +1,56 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import com.day.cq.wcm.api.components.ComponentManager;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the {@code FindOrphanedComponents.groovy} sample: recurses content and tables nodes whose sling:resourceType
+ * is not a registered component.
+ * <p>
+ * aem-mock's {@code ComponentManager.getComponents()} throws {@code UnsupportedOperationException}, so this test
+ * registers a mock ComponentManager as the adapter for {@code resourceResolver.adaptTo(ComponentManager)}.
+ */
+@ExtendWith(AemContextExtension.class)
+class FindOrphanedComponentsTest {
+
+    private final ComponentManager componentManager = mock(ComponentManager.class);
+
+    private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK)
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @BeforeEach
+    void registerComponentManager() {
+        when(componentManager.getComponents()).thenReturn(List.of());
+        context.registerAdapter(ResourceResolver.class, ComponentManager.class, componentManager);
+    }
+
+    @Test
+    void tablesNodesWithUnregisteredResourceTypes() {
+        context.create().page("/content/we-retail", "template", "We Retail");
+        context.create().resource("/content/we-retail/jcr:content/root",
+                "sling:resourceType", "weretail/components/nonexistent");
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("FindOrphanedComponents.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+        assertTrue(response.getResult().contains("weretail/components/nonexistent"),
+                "expected the orphaned resource type in the table but was: " + response.getResult());
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/FindPagesWithPropertyTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/FindPagesWithPropertyTest.java
@@ -1,0 +1,46 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import com.day.cq.wcm.api.NameConstants;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@code FindPagesWithProperty.groovy} sample: prints pages under we-retail that are not hidden in nav.
+ */
+@ExtendWith(AemContextExtension.class)
+class FindPagesWithPropertyTest {
+
+    private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK)
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void printsPagesShownInNavigation() {
+        context.create().page("/content/we-retail", "template", "We Retail");
+        context.create().page("/content/we-retail/men", "template", "Men");
+        context.create().page("/content/we-retail/hidden", "template",
+                Map.of(NameConstants.PN_HIDE_IN_NAV, true));
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("FindPagesWithProperty.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+        List<String> lines = response.getOutput().lines().collect(Collectors.toList());
+        assertTrue(lines.contains("/content/we-retail"));
+        assertTrue(lines.contains("/content/we-retail/men"));
+        assertFalse(lines.contains("/content/we-retail/hidden"));
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/FindPagesWithTemplateTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/FindPagesWithTemplateTest.java
@@ -1,0 +1,39 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@code FindPagesWithTemplate.groovy} sample: prints pages whose cq:template matches a specific template.
+ */
+@ExtendWith(AemContextExtension.class)
+class FindPagesWithTemplateTest {
+
+    private static final String TEMPLATE = "/conf/we-retail/settings/wcm/templates/section-page";
+
+    private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK)
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void printsPagesUsingTheTemplate() {
+        context.create().page("/content/we-retail", "otherTemplate", "We Retail");
+        // The 2nd arg becomes the cq:template property on jcr:content.
+        context.create().page("/content/we-retail/products", TEMPLATE, "Products");
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("FindPagesWithTemplate.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+        assertEquals("/content/we-retail/products" + System.lineSeparator(), response.getOutput());
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/FindReferencesTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/FindReferencesTest.java
@@ -1,0 +1,34 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@code FindReferences.groovy} sample: uses com.day.cq.wcm.commons.ReferenceSearch over the resolver and
+ * builds a table of references. With no references present the search returns an empty result.
+ */
+@ExtendWith(AemContextExtension.class)
+class FindReferencesTest {
+
+    private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK)
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void runsReferenceSearch() {
+        context.create().page("/content/we-retail", "template", "We Retail");
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("FindReferences.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/FulltextQueryTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/FulltextQueryTest.java
@@ -1,0 +1,63 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import com.day.cq.search.Query;
+import com.day.cq.search.QueryBuilder;
+import com.day.cq.search.result.Hit;
+import com.day.cq.search.result.SearchResult;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.jcr.Node;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the {@code FulltextQuery.groovy} sample: builds a QueryBuilder query and prints the hits. Shows how to supply
+ * a configured AEM OSGi service: the {@link QueryBuilder} is registered via {@code beforeSetUp(...)} before
+ * {@link ContextPlugins#GROOVY_CONSOLE}.
+ */
+@ExtendWith(AemContextExtension.class)
+class FulltextQueryTest {
+
+    private final Node node = mock(Node.class);
+    private final Hit hit = mock(Hit.class);
+    private final SearchResult searchResult = mock(SearchResult.class);
+    private final Query query = mock(Query.class);
+    private final QueryBuilder queryBuilder = mock(QueryBuilder.class);
+
+    private final AemContext context = new AemContextBuilder()
+            .beforeSetUp(osgiContext -> osgiContext.registerService(QueryBuilder.class, queryBuilder))
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @BeforeEach
+    void stubQuery() throws Exception {
+        when(node.getPath()).thenReturn("/content/we-retail/en");
+        when(hit.getNode()).thenReturn(node);
+        when(searchResult.getTotalMatches()).thenReturn(1L);
+        when(searchResult.getExecutionTime()).thenReturn("0.1");
+        when(searchResult.getHits()).thenReturn(List.of(hit));
+        when(query.getResult()).thenReturn(searchResult);
+        when(queryBuilder.createQuery(any(), any())).thenReturn(query);
+    }
+
+    @Test
+    void printsQueryHits() {
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("FulltextQuery.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+        assertTrue(response.getOutput().contains("1 hits"), response.getOutput());
+        assertTrue(response.getOutput().contains("hit path = /content/we-retail/en"), response.getOutput());
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/JcrSearchTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/JcrSearchTest.java
@@ -1,0 +1,34 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@code JcrSearch.groovy} sample: builds an XPath query via the JCR QueryManager and prints the results.
+ */
+@ExtendWith(AemContextExtension.class)
+class JcrSearchTest {
+
+    private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK)
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void runsXPathQuery() {
+        context.create().page("/content/we-retail", "template", "We Retail");
+        context.create().page("/content/we-retail/bikes", "template", "Bike");
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("JcrSearch.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/ListTemplatesTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/ListTemplatesTest.java
@@ -1,0 +1,39 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@code ListTemplates.groovy} sample: recurses pages and prints the distinct template paths in use.
+ */
+@ExtendWith(AemContextExtension.class)
+class ListTemplatesTest {
+
+    private static final String TEMPLATE = "/conf/we-retail/settings/wcm/templates/section-page";
+
+    private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK)
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void printsTemplatesInUse() {
+        context.create().resource(TEMPLATE, "jcr:primaryType", "cq:Template");
+        context.create().page("/content/we-retail", TEMPLATE, "We Retail");
+        context.create().page("/content/we-retail/men", TEMPLATE, "Men");
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("ListTemplates.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+        assertTrue(response.getOutput().contains(TEMPLATE),
+                "expected the template path in the output but was: [" + response.getOutput() + "]");
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/Samples.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/Samples.java
@@ -1,0 +1,27 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Reads a shipped sample script from this module's content so tests exercise the exact {@code .groovy} that is deployed.
+ */
+final class Samples {
+
+    private static final Path DIR =
+            Path.of("src/main/content/jcr_root/conf/groovyconsole/scripts/samples");
+
+    private Samples() {
+    }
+
+    static String read(String fileName) {
+        try {
+            return Files.readString(DIR.resolve(fileName), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/UpdateOsgiConfigurationTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/UpdateOsgiConfigurationTest.java
@@ -1,0 +1,48 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@code UpdateOsgiConfiguration.groovy} sample: appends a mapping to an existing OSGi configuration.
+ */
+@ExtendWith(AemContextExtension.class)
+class UpdateOsgiConfigurationTest {
+
+    private static final String PID = "org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl";
+
+    private final AemContext context = new AemContextBuilder()
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void appendsResourceResolverMapping() throws Exception {
+        ConfigurationAdmin configurationAdmin = context.getService(ConfigurationAdmin.class);
+
+        Dictionary<String, Object> seed = new Hashtable<>();
+        seed.put("resource.resolver.mapping", new String[]{"/:/"});
+        configurationAdmin.getConfiguration(PID).update(seed);
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("UpdateOsgiConfiguration.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+
+        String[] mappings = (String[]) configurationAdmin.getConfiguration(PID)
+                .getProperties().get("resource.resolver.mapping");
+        assertTrue(Arrays.asList(mappings).contains("/content/we-retail/:/wr/"),
+                "expected the new mapping but was: " + Arrays.toString(mappings));
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/UpdatePageTitlesTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/samples/UpdatePageTitlesTest.java
@@ -1,0 +1,45 @@
+package be.orbinson.aem.groovy.console.samples;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import com.day.cq.wcm.api.NameConstants;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the {@code UpdatePageTitles.groovy} sample. It reads and writes JCR content (getPage/recurse/node/set/save)
+ */
+@ExtendWith(AemContextExtension.class)
+class UpdatePageTitlesTest {
+
+    private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK)
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void rewritesPageTitlesUnderWeRetail() {
+        context.create().page("/content/we-retail", "template", "We Retail");
+        context.create().page("/content/we-retail/men", "template", "Men");
+
+        RunScriptResponse response = GroovyConsole.runScript(context, Samples.read("UpdatePageTitles.groovy"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+        assertEquals("We Retail | We Retail", pageTitle("/content/we-retail"));
+        assertEquals("Men | We Retail", pageTitle("/content/we-retail/men"));
+    }
+
+    private String pageTitle(String pagePath) {
+        return context.resourceResolver()
+                .getResource(pagePath + "/jcr:content")
+                .getValueMap()
+                .get(NameConstants.PN_PAGE_TITLE, String.class);
+    }
+}


### PR DESCRIPTION
## What

Adds a reusable JUnit 5 / AEM Mocks harness so projects can unit-test their Groovy Console scripts, and covers every `ui.content` sample script with it.

### `test-support` module (`aem-groovy-console-test-support`)
- **`ContextPlugins.GROOVY_CONSOLE`** — a Sling Mock `ContextPlugin` that registers the full default extension stack (bindings, script metaclasses incl. OSGi, type metaclasses incl. Sling, star imports). Collaborator services are only mocked when absent, so consumers can supply their own (e.g. a configured `QueryBuilder`).
- **`GroovyConsole.runScript(context, script)`** — stateless run helper returning `RunScriptResponse`.

Consumers add one test-scoped dependency and write:
```java
private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_MOCK)
        .plugin(ContextPlugins.GROOVY_CONSOLE).build();
// ...
RunScriptResponse response = GroovyConsole.runScript(context, "println getPage('/content/site').path");
```

### Lazy session resolution
`AbstractContentBuilder` now resolves the JCR root node lazily, so `NodeBuilder`/`PageBuilder` no longer dereference the session at bind time. **`JCR_MOCK` is now only required for scripts that actually touch the JCR** — non-JCR scripts run under the default resolver.

### Sample coverage (`ui.content/src/test`)
One test per shipped sample script, plus `SampleScriptsTest` for the inline-snippet pattern. Surfaced and worked around real aem-mock limitations (documented in the tests): `MockComponentManager.getComponents()` unsupported (use `registerAdapter`), `MockPage.getTemplate()` needs the `cq:Template` resource, `ConfigurationAdmin` must not be replaced with a bare mock.

### Sample fix
`CreateOsgiConfigurations` now uses the idempotent `getFactoryConfiguration` API instead of the legacy `createFactoryConfiguration`; fixed a logger-name typo.

### Test dependency upgrade
aem-mock `5.7.4`, sling-mock-oak `4.1.0-1.86.0`, mockito-core `5.21.0`, junit-bom `5.11.4`, maven-surefire `3.5.2`.

## Testing
`mvn test -pl bundle,ui.content` — bundle 11/11, ui.content 13/13 green.