### PR TITLE
Add Oak query-index detection for Groovy scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   JCR-backed mock is only needed for scripts that actually touch the repository.
 - **Query-audit extension** — an optional debugging tool that reports, for every JCR query a Groovy script runs,
   whether the live Oak instance has an index that covers it, so you can catch un-indexed queries in migration/report
-  scripts before shipping. Callable via `POST /bin/groovyconsole/query-audit` or a **Query audit panel** in the modern
-  console. When installed alongside the migration extension, a migration run started with `measureIndexUsage=true`
-  reports per-script index usage (handy for validating migrations in CI). Ships as its own bundle, outside the core
-  `all` package.
+  scripts before shipping. Callable via `POST /bin/groovyconsole/query-audit` or, in the modern console, via
+  **Run with query audit** in the Run button's options menu — the per-query verdicts (with the Oak plan) appear in a
+  **Query audit** tab in the output dock. The `AuditQueryIndexes` sample script demonstrates it with an indexed and an
+  un-indexed query. When installed alongside the migration extension, a migration run started with
+  `measureIndexUsage=true` reports per-script index usage (handy for validating migrations in CI). Ships as its own
+  bundle, outside the core `all` package.
+- The modern console's UI extension contract now supports run actions (`GroovyConsole.registerRunAction`, shown in a
+  split-button menu next to Run) and output-dock result tabs (`GroovyConsole.registerRunResultTab`), in addition to
+  activity-rail panels.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Script unit-testing support** — a new `aem-groovy-console-test-support` module: a JUnit 5 / AEM Mocks harness to
   unit-test Groovy Console scripts in a few lines (add a context plugin, run a script, assert on the result). A
   JCR-backed mock is only needed for scripts that actually touch the repository.
+- **Query-audit extension** — an optional debugging tool that reports, for every JCR query a Groovy script runs,
+  whether the live Oak instance has an index that covers it, so you can catch un-indexed queries in migration/report
+  scripts before shipping. Callable via `POST /bin/groovyconsole/query-audit` or a **Query audit panel** in the modern
+  console. When installed alongside the migration extension, a migration run started with `measureIndexUsage=true`
+  reports per-script index usage (handy for validating migrations in CI). Ships as its own bundle, outside the core
+  `all` package.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -322,8 +322,9 @@ Two rules make this work:
   removing an extension's package removes its code paths entirely.
 * **Extensions integrate only through the console's public APIs** — the script-execution SPIs listed above, plus
   the `be.orbinson.aem.groovy.console.api.ConsoleUiExtensionProvider` SPI, which lets an extension contribute
-  panels to the modern UI's activity rail. The console announces the registered module URLs to its SPA, which
-  loads them dynamically and exposes a small registration API (`window.GroovyConsole.registerPanel(...)`).
+  to the modern UI: activity-rail panels, entries in the Run button's options menu, and result tabs in the
+  output dock. The console announces the registered module URLs to its SPA, which loads them dynamically and
+  exposes a small registration API (`window.GroovyConsole.registerPanel/registerRunAction/registerRunResultTab`).
   Extensions interact with the shell only through this API and DOM events, never through compile-time coupling.
 
 To use an extension, install the console first, then deploy the extension's content package.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -19,13 +19,23 @@ An extension may only touch the console through its **public APIs** — never by
 |---|---|---|
 | Script execution | `GroovyConsoleService.runScript(ScriptContext)` | Run Groovy with all console bindings, star imports, metaclasses, timeout and audit. |
 | Bindings / imports / metaclasses | `BindingExtensionProvider`, `StarImportExtensionProvider`, `CompilationCustomizerExtensionProvider`, `ScriptMetaClassExtensionProvider` | Add your own bindings/imports for scripts your extension runs (gate on your own `ScriptContext` marker type). |
-| Modern UI panels | `be.orbinson.aem.groovy.console.api.ConsoleUiExtensionProvider` (OSGi service returning ES module URLs) | Contribute a panel to the console's activity rail. |
+| Modern UI hooks | `be.orbinson.aem.groovy.console.api.ConsoleUiExtensionProvider` (OSGi service returning ES module URLs) | Contribute activity-rail panels, run actions, and output-dock result tabs to the console. |
 | Its own pages/endpoints | Path-bound Sling servlets under your own path | Serve your extension's UI shell and JSON API; they exist only when the extension is installed. |
 
-On the frontend, an announced module is loaded dynamically by the console SPA and registers panels via the
-`window.GroovyConsole.registerPanel({ id, title, element, iconHtml })` global. Panels are self-contained custom
-elements and talk to the shell **only through DOM events** — `gc-set-script` (`{ script, message? }`) and
-`gc-toast` (`{ message, variant? }`) — never via imports. The console stays fully functional with no providers.
+On the frontend, an announced module is loaded dynamically by the console SPA and registers its hooks via the
+`window.GroovyConsole` global:
+
+- `registerPanel({ id, title, element, iconHtml })` — a drawer panel behind an activity-rail button (see reports).
+- `registerRunAction({ id, label, run })` — an entry in the Run button's options menu (the chevron only appears
+  when at least one action is registered). `run({ script, data })` executes the current script your way and
+  resolves to a `RunScriptResponse`-shaped object; extra fields are kept on the stored result.
+- `registerRunResultTab({ id, label, element, isRelevant })` — a tab in the output dock next to Log/Result, shown
+  when `isRelevant(result)` is true (typically: your run action attached an extra field). The dock renders your
+  custom element and assigns the run result to its `result` property (see query-audit).
+
+Panels and result tabs are self-contained custom elements and talk to the shell **only through DOM events** —
+`gc-set-script` (`{ script, message? }`) and `gc-toast` (`{ message, variant? }`) — never via imports. The console
+stays fully functional with no providers.
 
 ## Module layout (mirror `reports/`)
 
@@ -59,8 +69,9 @@ the extension bundle (so the page only exists when the extension is installed).
    `ServiceUserMapper` amendment. Enforce permissions in every servlet *before* any service-resolver read.
 6. **Optional 3rd-party deps** (e.g. POI): isolate them in a separate bundle with wide OSGi import ranges so the
    core extension degrades gracefully when the provider is absent (see `reports/exporter-xlsx`).
-7. **UI panel** (optional): register a `ConsoleUiExtensionProvider` returning your ES module URL(s); build the
-   module as a Vite entry; register panels via `window.GroovyConsole.registerPanel(...)`.
+7. **UI hooks** (optional): register a `ConsoleUiExtensionProvider` returning your ES module URL(s); build the
+   module as a Vite entry (or ship a plain ES module like query-audit); register panels, run actions, and result
+   tabs via the `window.GroovyConsole` globals described above.
 8. **Package**: the `all` module embeds your bundles + content packages into a single
    `aem-groovy-console-<name>-all` zip. Do **not** add it to the console's `all` package.
 9. **Tests**:

--- a/extensions/migration/api/src/main/groovy/be/orbinson/aem/groovy/console/migration/MigrationRunOptions.groovy
+++ b/extensions/migration/api/src/main/groovy/be/orbinson/aem/groovy/console/migration/MigrationRunOptions.groovy
@@ -31,4 +31,10 @@ class MigrationRunOptions {
      * Mirrors {@code AecuService.execute(String path, String data)}.
      */
     String data
+
+    /**
+     * If true, measure the Oak index usage of the queries each migration script runs (requires the optional
+     * query-audit extension to be installed; otherwise it is a no-op). Intended for CI validation.
+     */
+    boolean measureIndexUsage
 }

--- a/extensions/migration/api/src/main/groovy/be/orbinson/aem/groovy/console/migration/MigrationScriptResult.groovy
+++ b/extensions/migration/api/src/main/groovy/be/orbinson/aem/groovy/console/migration/MigrationScriptResult.groovy
@@ -32,4 +32,14 @@ interface MigrationScriptResult {
     String getOutput()
 
     String getError()
+
+    /**
+     * Index audit of the JCR queries this script executed, when the run was started with
+     * {@link MigrationRunOptions#measureIndexUsage} and the query-audit extension is installed. Each entry is a map
+     * with keys {@code statement}, {@code plan} and {@code needsIndex}; {@code needsIndex=true} means Oak had to
+     * traverse (no covering index on this instance). Empty when not measured.
+     *
+     * @return per-query index audit (possibly empty)
+     */
+    List<Map<String, Object>> getQueryAudit()
 }

--- a/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/DefaultMigrationScriptResult.groovy
+++ b/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/DefaultMigrationScriptResult.groovy
@@ -26,6 +26,9 @@ class DefaultMigrationScriptResult implements MigrationScriptResult {
 
     String error
 
+    /** Per-query index audit (statement/plan/needsIndex maps); empty unless index usage was measured. */
+    List<Map<String, Object>> queryAudit = []
+
     static DefaultMigrationScriptResult fromResource(Resource resource) {
         def properties = resource.valueMap
 

--- a/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/DefaultMigrationService.groovy
+++ b/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/DefaultMigrationService.groovy
@@ -26,6 +26,8 @@ import org.apache.sling.settings.SlingSettingsService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceCardinality
+import org.osgi.service.component.annotations.ReferencePolicy
 import org.osgi.service.metatype.annotations.Designate
 
 import java.nio.charset.StandardCharsets
@@ -59,6 +61,16 @@ class DefaultMigrationService implements MigrationService {
 
     @Reference
     private SlingSettingsService slingSettingsService
+
+    /**
+     * Optional index-usage auditor. Present only when the query-audit extension is installed (a bridge component
+     * registers a {@link ScriptIndexAuditor} then); absent (null) otherwise — e.g. on AEM as a Cloud Service — in
+     * which case index measurement is silently skipped. This service is referenced through the migration-owned
+     * {@link ScriptIndexAuditor} interface (never the query-audit types), so this component always loads and
+     * activates whether or not the query-audit extension is present.
+     */
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    private volatile ScriptIndexAuditor scriptIndexAuditor
 
     private String scriptsBasePath
 
@@ -106,9 +118,13 @@ class DefaultMigrationService implements MigrationService {
                     results = pendingScripts.collect { script -> dryRunResult(script) }
                     status = MigrationStatus.SUCCESS
                 } else {
-                    results = executeScripts(resourceResolver, pendingScripts, options.data)
+                    results = executeScripts(resourceResolver, pendingScripts, options.data, options.measureIndexUsage)
                     status = results.any { result -> result.status == MigrationStatus.FAILED } ?
                             MigrationStatus.FAILED : MigrationStatus.SUCCESS
+
+                    if (options.measureIndexUsage) {
+                        reportIndexUsage(results)
+                    }
                 }
 
                 def endDate = Calendar.instance
@@ -381,7 +397,8 @@ class DefaultMigrationService implements MigrationService {
 
     // execution
 
-    private List<MigrationScriptResult> executeScripts(ResourceResolver resourceResolver, List<Map> pendingScripts, String data) {
+    private List<MigrationScriptResult> executeScripts(ResourceResolver resourceResolver, List<Map> pendingScripts,
+                                                       String data, boolean measureIndexUsage) {
         def results = []
 
         def failed = false
@@ -402,7 +419,7 @@ class DefaultMigrationService implements MigrationService {
                         error: ""
                 )
             } else {
-                result = executeScript(resourceResolver, script, data)
+                result = executeScript(resourceResolver, script, data, measureIndexUsage)
                 failed = result.status == MigrationStatus.FAILED
 
                 if (failed) {
@@ -420,7 +437,7 @@ class DefaultMigrationService implements MigrationService {
         results
     }
 
-    private MigrationScriptResult executeScript(ResourceResolver resourceResolver, Map script, String data) {
+    private MigrationScriptResult executeScript(ResourceResolver resourceResolver, Map script, String data, boolean measureIndexUsage) {
         LOG.info("executing migration script : {}", script.path)
 
         def started = System.currentTimeMillis()
@@ -435,7 +452,24 @@ class DefaultMigrationService implements MigrationService {
                 data: data
         )
 
-        def response = groovyConsoleService.runScript(scriptContext)
+        def response
+        def queryAudit = []
+
+        def auditor = scriptIndexAuditor
+
+        if (measureIndexUsage && auditor) {
+            // Wrap execution so the query-audit extension captures each query and reports its Oak index usage.
+            // The closure assigns the enclosing `response` directly (Groovy closures capture by reference).
+            def session = resourceResolver.adaptTo(javax.jcr.Session)
+
+            queryAudit = auditor.audit(session, { response = groovyConsoleService.runScript(scriptContext) } as Runnable)
+        } else {
+            if (measureIndexUsage) {
+                LOG.warn("index usage requested but the query-audit extension is not installed; skipping measurement")
+            }
+
+            response = groovyConsoleService.runScript(scriptContext)
+        }
 
         def durationMillis = System.currentTimeMillis() - started
 
@@ -446,8 +480,27 @@ class DefaultMigrationService implements MigrationService {
                 runningTime: formatRunningTime(durationMillis),
                 durationMillis: durationMillis,
                 output: truncate(response.output),
-                error: truncate(response.exceptionStackTrace)
+                error: truncate(response.exceptionStackTrace),
+                queryAudit: queryAudit
         )
+    }
+
+    /** Log a CI-friendly summary of which migration scripts run queries that lack a covering index. */
+    private void reportIndexUsage(List<MigrationScriptResult> results) {
+        def flagged = results.findAll { result -> result.queryAudit.any { query -> query.needsIndex } }
+
+        if (flagged.isEmpty()) {
+            LOG.info("index audit: all migration scripts' queries are backed by an index")
+            return
+        }
+
+        LOG.warn("index audit: {} migration script(s) run queries with no covering index:", flagged.size())
+
+        flagged.each { result ->
+            result.queryAudit.findAll { query -> query.needsIndex }.each { query ->
+                LOG.warn("  {} -> NEEDS INDEX: {}", result.scriptPath, query.statement)
+            }
+        }
     }
 
     private MigrationScriptResult dryRunResult(Map script) {

--- a/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/QueryAuditScriptIndexAuditor.groovy
+++ b/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/QueryAuditScriptIndexAuditor.groovy
@@ -1,0 +1,26 @@
+package be.orbinson.aem.groovy.console.migration.impl
+
+import be.orbinson.aem.groovy.console.queryaudit.spi.QueryAuditService
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+
+import javax.jcr.Session
+import java.util.function.Supplier
+
+/**
+ * Bridges the migration extension to the optional query-audit extension. Its mandatory {@link QueryAuditService}
+ * reference means Declarative Services only loads and registers this component when the query-audit bundle is
+ * present — so {@link DefaultMigrationService}, which references only {@link ScriptIndexAuditor}, never touches a
+ * query-audit type and keeps working when the extension is absent (e.g. AEM as a Cloud Service).
+ */
+@Component(service = ScriptIndexAuditor)
+class QueryAuditScriptIndexAuditor implements ScriptIndexAuditor {
+
+    @Reference
+    private QueryAuditService queryAuditService
+
+    @Override
+    List<Map<String, Object>> audit(Session session, Runnable work) {
+        queryAuditService.audit(session, { work.run(); null } as Supplier).queries.collect { it.toMap() }
+    }
+}

--- a/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/ScriptIndexAuditor.groovy
+++ b/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/ScriptIndexAuditor.groovy
@@ -1,0 +1,18 @@
+package be.orbinson.aem.groovy.console.migration.impl
+
+import javax.jcr.Session
+
+/**
+ * Migration-owned abstraction over the optional query-audit extension. Deliberately references none of the
+ * query-audit types so that {@link DefaultMigrationService} — and therefore the whole migration extension —
+ * loads and activates whether or not the query-audit bundle is installed (e.g. on AEM as a Cloud Service, where
+ * it cannot be). The bridge implementation is registered only when query-audit is present.
+ */
+interface ScriptIndexAuditor {
+
+    /**
+     * Run {@code work}, capturing every JCR query it executes, and report each query's Oak index usage as a plain
+     * map (keys: {@code statement}, {@code plan}, {@code needsIndex}).
+     */
+    List<Map<String, Object>> audit(Session session, Runnable work)
+}

--- a/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/servlets/MigrationServlet.groovy
+++ b/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/servlets/MigrationServlet.groovy
@@ -84,7 +84,8 @@ class MigrationServlet extends SlingAllMethodsServlet {
                     trigger: TRIGGER_API,
                     dryRun: Boolean.parseBoolean(request.getParameter(DRY_RUN)),
                     path: request.getParameter(PATH),
-                    data: request.getParameter(DATA)
+                    data: request.getParameter(DATA),
+                    measureIndexUsage: Boolean.parseBoolean(request.getParameter("measureIndexUsage"))
             )
 
             try {
@@ -142,7 +143,7 @@ class MigrationServlet extends SlingAllMethodsServlet {
     }
 
     private static Map resultToMap(MigrationScriptResult result) {
-        [
+        def map = [
                 scriptPath    : result.scriptPath,
                 checksum      : result.checksum,
                 status        : result.status.name(),
@@ -151,5 +152,11 @@ class MigrationServlet extends SlingAllMethodsServlet {
                 output        : result.output,
                 error         : result.error
         ]
+
+        if (result.queryAudit) {
+            map.queryAudit = result.queryAudit
+        }
+
+        map
     }
 }

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -25,6 +25,7 @@
     <modules>
         <module>reports</module>
         <module>migration</module>
+        <module>query-audit</module>
     </modules>
 
 </project>

--- a/extensions/query-audit/pom.xml
+++ b/extensions/query-audit/pom.xml
@@ -7,13 +7,19 @@
 
     <parent>
         <groupId>be.orbinson.aem</groupId>
-        <artifactId>aem-groovy-console-migration</artifactId>
+        <artifactId>aem-groovy-console-extensions</artifactId>
         <version>20.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>aem-groovy-console-migration-bundle</artifactId>
-    <name>AEM Groovy Console - Migration Bundle</name>
+    <artifactId>aem-groovy-console-query-audit</artifactId>
+    <name>AEM Groovy Console - Query Audit Extension</name>
+    <description>
+        Optional debugging extension: a servlet that runs a Groovy Console script and reports, per JCR query it
+        executes, whether the live Oak repository has an index that covers it. A single OSGi bundle — no content
+        package. It captures Oak's query logs via logback, so it is intended for local / on-prem / non-Cloud use
+        (AEM as a Cloud Service does not support the logback manipulation this relies on).
+    </description>
 
     <build>
         <plugins>
@@ -32,7 +38,8 @@
                         </goals>
                         <configuration>
                             <bnd><![CDATA[
-                                Import-Package: be.orbinson.aem.groovy.console.queryaudit.spi;resolution:=optional,*
+                                Import-Package: ch.qos.logback.*;resolution:=optional,com.day.cq.*;resolution:=optional,*
+                                DynamicImport-Package: *
                                 ]]></bnd>
                         </configuration>
                     </execution>
@@ -56,29 +63,11 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>be.orbinson.aem</groupId>
-            <artifactId>aem-groovy-console-migration-api</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- Optional query-audit SPI: provided (compile-only). At runtime the package is imported optionally, so
-             migration works whether or not the query-audit extension is installed. -->
-        <dependency>
-            <groupId>be.orbinson.aem</groupId>
-            <artifactId>aem-groovy-console-query-audit</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Compile -->
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component.annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.service.metatype.annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -110,49 +99,19 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <!-- Logback: the SLF4J backend used to capture Oak's query logs. Not bundled; resolved at runtime. -->
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.13</version>
+            <scope>provided</scope>
         </dependency>
-
-        <!-- Groovy -->
-        <dependency>
-            <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy</artifactId>
-        </dependency>
+        <!-- groovy-json (JsonOutput) for the servlet response. Compile-only; groovy.json is resolved at runtime
+             from the console's embedded Groovy via the bundle's DynamicImport-Package. -->
         <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-json</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy-dateutil</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.groovy</groupId>
-            <artifactId>groovy-groovydoc</artifactId>
-        </dependency>
-
-        <!-- Test -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.wcm</groupId>
-            <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryAuditConsoleUiExtensionProvider.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryAuditConsoleUiExtensionProvider.java
@@ -1,0 +1,26 @@
+package be.orbinson.aem.groovy.console.queryaudit;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+
+import be.orbinson.aem.groovy.console.api.ConsoleUiExtensionProvider;
+
+/**
+ * Announces the query-audit panel module to the modern console UI. The module (served by
+ * {@link QueryAuditPanelServlet}) registers a "Query audit" panel in the console's activity rail via
+ * {@code window.GroovyConsole.registerPanel(...)}. When the query-audit extension is not installed this service is
+ * absent and the console UI stays untouched.
+ */
+@Component(service = ConsoleUiExtensionProvider.class, immediate = true)
+public class QueryAuditConsoleUiExtensionProvider implements ConsoleUiExtensionProvider {
+
+    private static final List<String> MODULE_URLS =
+            Collections.singletonList("/bin/groovyconsole/query-audit-panel.js");
+
+    @Override
+    public List<String> getModuleUrls() {
+        return MODULE_URLS;
+    }
+}

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryAuditPanelServlet.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryAuditPanelServlet.java
@@ -1,0 +1,50 @@
+package be.orbinson.aem.groovy.console.queryaudit;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Serves the query-audit panel ES module for the modern console UI. Keeping the module in the bundle (rather than a
+ * content package) lets the query-audit extension stay a single bundle. The module is announced by
+ * {@link QueryAuditConsoleUiExtensionProvider} and imported by the console SPA at startup.
+ */
+@Component(service = Servlet.class, immediate = true, property = {
+        "sling.servlet.paths=/bin/groovyconsole/query-audit-panel.js"
+})
+public class QueryAuditPanelServlet extends SlingSafeMethodsServlet {
+
+    private static final String MODULE_RESOURCE = "/query-audit-panel.js";
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException {
+        response.setContentType("application/javascript");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        try (InputStream module = getClass().getResourceAsStream(MODULE_RESOURCE)) {
+            if (module == null) {
+                response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
+            response.getWriter().write(new String(readAll(module), StandardCharsets.UTF_8));
+        }
+    }
+
+    private static byte[] readAll(InputStream in) throws IOException {
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        byte[] chunk = new byte[4096];
+        int read;
+        while ((read = in.read(chunk)) != -1) {
+            out.write(chunk, 0, read);
+        }
+        return out.toByteArray();
+    }
+}

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryAuditServlet.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryAuditServlet.java
@@ -1,0 +1,140 @@
+package be.orbinson.aem.groovy.console.queryaudit;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+
+import javax.jcr.Session;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import groovy.json.JsonOutput;
+
+import be.orbinson.aem.groovy.console.GroovyConsoleService;
+import be.orbinson.aem.groovy.console.api.context.impl.RequestScriptContext;
+import be.orbinson.aem.groovy.console.configuration.ConfigurationService;
+import be.orbinson.aem.groovy.console.queryaudit.spi.AuditResult;
+import be.orbinson.aem.groovy.console.queryaudit.spi.AuditedQuery;
+import be.orbinson.aem.groovy.console.queryaudit.spi.QueryAuditService;
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+
+/**
+ * Debugging endpoint that runs a Groovy Console script and reports, for every JCR query it executes, whether the live
+ * Oak repository has an index that covers it. Same permission model as script execution.
+ * <p>
+ * {@code POST /bin/groovyconsole/query-audit} with either a {@code script} (source) or a {@code scriptPath} (JCR path
+ * of a saved/deployed script). Returns JSON:
+ * <pre>
+ * { "output": "...", "exceptionStackTrace": "",
+ *   "queries": [ { "statement": "...", "plan": "...", "needsIndex": true } ] }
+ * </pre>
+ * {@code needsIndex=true} means Oak had to traverse — no index on this instance covers that query.
+ */
+@Component(service = Servlet.class, immediate = true, property = {
+        "sling.servlet.paths=/bin/groovyconsole/query-audit"
+})
+public class QueryAuditServlet extends SlingAllMethodsServlet {
+
+    @Reference
+    private transient ConfigurationService configurationService;
+
+    @Reference
+    private transient GroovyConsoleService consoleService;
+
+    @Reference
+    private transient QueryAuditService queryAuditService;
+
+    @Override
+    protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        if (!configurationService.hasPermission(request)) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+
+        String script = getScript(request);
+        if (script == null || script.isEmpty()) {
+            writeError(response, "Script cannot be empty.");
+            return;
+        }
+
+        Session session = request.getResourceResolver().adaptTo(Session.class);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        RequestScriptContext scriptContext = new RequestScriptContext(
+                request, response, outputStream, printStream(outputStream), script);
+
+        // The console service runs a script from its content (there is no run-by-path API — the core
+        // ScriptPostServlet loads by path the same way), so the audited work simply executes the script and its
+        // RunScriptResponse comes back on the AuditResult, no mutable holder needed.
+        AuditResult<RunScriptResponse> audit = queryAuditService.audit(session, () -> consoleService.runScript(scriptContext));
+
+        writeReport(response, audit.getResult(), audit.getQueries());
+    }
+
+    private String getScript(SlingHttpServletRequest request) throws IOException {
+        String scriptPath = request.getParameter("scriptPath");
+        if (scriptPath != null && !scriptPath.isEmpty()) {
+            return loadScript(request, scriptPath);
+        }
+        return request.getParameter("script");
+    }
+
+    /** Read the content of a saved/deployed script (an {@code nt:file}) from the repository. */
+    private String loadScript(SlingHttpServletRequest request, String scriptPath) throws IOException {
+        try (InputStream stream = request.getResourceResolver().getResource(scriptPath).adaptTo(InputStream.class);
+             Scanner scanner = new Scanner(stream, StandardCharsets.UTF_8.name())) {
+            return scanner.useDelimiter("\\A").hasNext() ? scanner.next() : "";
+        }
+    }
+
+    private void writeReport(SlingHttpServletResponse response, RunScriptResponse runScriptResponse,
+                             List<AuditedQuery> queries) throws IOException {
+        Map<String, Object> report = new LinkedHashMap<>();
+        report.put("output", runScriptResponse != null ? runScriptResponse.getOutput() : null);
+        report.put("exceptionStackTrace", runScriptResponse != null ? runScriptResponse.getExceptionStackTrace() : null);
+        List<Map<String, Object>> auditedQueries = new ArrayList<>();
+        for (AuditedQuery query : queries) {
+            auditedQueries.add(query.toMap());
+        }
+        report.put("queries", auditedQueries);
+        write(response, JsonOutput.toJson(report));
+    }
+
+    private void writeError(SlingHttpServletResponse response, String message) throws IOException {
+        write(response, JsonOutput.toJson(Collections.singletonMap("error", message)));
+    }
+
+    private void write(SlingHttpServletResponse response, String json) throws IOException {
+        response.setContentType("application/json");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        try (PrintWriter writer = response.getWriter()) {
+            writer.write(json);
+        }
+    }
+
+    private static PrintStream printStream(ByteArrayOutputStream outputStream) {
+        try {
+            return new PrintStream(outputStream, true, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryAuditServlet.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryAuditServlet.java
@@ -40,9 +40,9 @@ import be.orbinson.aem.groovy.console.response.RunScriptResponse;
  * Oak repository has an index that covers it. Same permission model as script execution.
  * <p>
  * {@code POST /bin/groovyconsole/query-audit} with either a {@code script} (source) or a {@code scriptPath} (JCR path
- * of a saved/deployed script). Returns JSON:
+ * of a saved/deployed script), plus an optional {@code data} parameter (same as a normal console run). Returns JSON:
  * <pre>
- * { "output": "...", "exceptionStackTrace": "",
+ * { "result": "...", "output": "...", "exceptionStackTrace": "", "runningTime": "...",
  *   "queries": [ { "statement": "...", "plan": "...", "needsIndex": true } ] }
  * </pre>
  * {@code needsIndex=true} means Oak had to traverse — no index on this instance covers that query.
@@ -108,8 +108,10 @@ public class QueryAuditServlet extends SlingAllMethodsServlet {
     private void writeReport(SlingHttpServletResponse response, RunScriptResponse runScriptResponse,
                              List<AuditedQuery> queries) throws IOException {
         Map<String, Object> report = new LinkedHashMap<>();
+        report.put("result", runScriptResponse != null ? runScriptResponse.getResult() : null);
         report.put("output", runScriptResponse != null ? runScriptResponse.getOutput() : null);
         report.put("exceptionStackTrace", runScriptResponse != null ? runScriptResponse.getExceptionStackTrace() : null);
+        report.put("runningTime", runScriptResponse != null ? runScriptResponse.getRunningTime() : null);
         List<Map<String, Object>> auditedQueries = new ArrayList<>();
         for (AuditedQuery query : queries) {
             auditedQueries.add(query.toMap());

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryPlanAuditor.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryPlanAuditor.java
@@ -9,6 +9,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.jcr.Session;
 import javax.jcr.query.Query;
@@ -48,6 +50,9 @@ public class QueryPlanAuditor implements QueryAuditService {
     private static final String EXECUTE_PREFIX = "query execute ";
 
     private static final String INTERNAL_MARKER = "oak-internal";
+
+    /** Oak logs an XPath query as its JCR-SQL2 conversion with the original appended as a trailing comment. */
+    private static final Pattern XPATH_COMMENT = Pattern.compile("/\\* xpath: (.*) \\*/\\s*$", Pattern.DOTALL);
 
     /** Oak's query engine logger and AEM's QueryBuilder logger. */
     private static final List<String> QUERY_LOGGERS = Arrays.asList(
@@ -96,7 +101,15 @@ public class QueryPlanAuditor implements QueryAuditService {
 
         List<AuditedQuery> results = new ArrayList<>();
         for (String statement : collectStatements(appender.list, marker)) {
-            results.add(new AuditedQuery(statement, explain(session, statement)));
+            String language = isSql2(statement) ? Query.JCR_SQL2 : Query.XPATH;
+            String plan = explain(session, statement, language);
+            // Report a converted XPath query as its original statement (the plan is the same either way).
+            Matcher xpath = XPATH_COMMENT.matcher(statement);
+            if (xpath.find()) {
+                results.add(new AuditedQuery(xpath.group(1), Query.XPATH, plan));
+            } else {
+                results.add(new AuditedQuery(statement, language, plan));
+            }
         }
         return new AuditResult<>(workResult, results);
     }
@@ -123,8 +136,7 @@ public class QueryPlanAuditor implements QueryAuditService {
      * statements as JCR-SQL2 (it converts XPath internally), but AEM's QueryBuilder logs XPath, so the language is
      * detected rather than assumed — and the reported statement/plan are then in whatever language Oak executed.
      */
-    private static String explain(Session session, String statement) {
-        String language = isSql2(statement) ? Query.JCR_SQL2 : Query.XPATH;
+    private static String explain(Session session, String statement, String language) {
         try {
             return session.getWorkspace().getQueryManager()
                     .createQuery("explain " + statement, language)

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryPlanAuditor.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/QueryPlanAuditor.java
@@ -1,0 +1,145 @@
+package be.orbinson.aem.groovy.console.queryaudit;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import be.orbinson.aem.groovy.console.queryaudit.spi.AuditResult;
+import be.orbinson.aem.groovy.console.queryaudit.spi.AuditedQuery;
+import be.orbinson.aem.groovy.console.queryaudit.spi.QueryAuditService;
+
+/**
+ * {@link QueryAuditService} implementation. Captures the statements Oak executes while running some work by listening
+ * to Oak's query loggers, then re-runs {@code EXPLAIN} against the same session so the reported plan reflects the
+ * instance's real indexes. Mirrors AEM's own "Explain Query" tool (a logback collector over the Oak query loggers),
+ * with two refinements: capture is isolated to the calling thread via an MDC marker (so queries other requests run
+ * concurrently do not pollute the result), and the QueryBuilder logger is included so scripts using
+ * {@code createQuery} are covered.
+ * <p>
+ * Oak logs {@code query execute}/{@code query plan} at DEBUG behind an {@code isDebugEnabled()} guard, so the audited
+ * loggers are briefly raised to DEBUG and restored afterwards.
+ */
+@Component(service = QueryAuditService.class)
+public class QueryPlanAuditor implements QueryAuditService {
+
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(QueryPlanAuditor.class);
+
+    private static final String MDC_KEY = "groovyconsole.queryAudit";
+
+    private static final String EXECUTE_PREFIX = "query execute ";
+
+    private static final String INTERNAL_MARKER = "oak-internal";
+
+    /** Oak's query engine logger and AEM's QueryBuilder logger. */
+    private static final List<String> QUERY_LOGGERS = Arrays.asList(
+            "org.apache.jackrabbit.oak.query.QueryImpl",
+            "com.day.cq.search.impl.builder.QueryImpl");
+
+    @Override
+    public <T> AuditResult<T> audit(Session session, Supplier<T> work) {
+        if (!(LoggerFactory.getILoggerFactory() instanceof LoggerContext)) {
+            // Query capture needs the logback backend (as in AEM/Sling). Degrade gracefully: run the work anyway.
+            LOG.warn("SLF4J backend is not logback; running without query capture");
+            return new AuditResult<>(work.get(), new ArrayList<>());
+        }
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        String marker = UUID.randomUUID().toString();
+
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.setContext(loggerContext);
+        appender.start();
+
+        // A logback logger with no explicitly-assigned level returns null from getLevel() (it inherits); restoring
+        // setLevel(null) simply reverts to inheriting. A plain map is fine since it may hold null values.
+        Map<String, Level> previousLevels = new LinkedHashMap<>();
+        List<Logger> loggers = new ArrayList<>();
+        for (String name : QUERY_LOGGERS) {
+            Logger logger = loggerContext.getLogger(name);
+            previousLevels.put(name, logger.getLevel());
+            logger.setLevel(Level.DEBUG);
+            logger.addAppender(appender);
+            loggers.add(logger);
+        }
+
+        T workResult;
+        MDC.put(MDC_KEY, marker);
+        try {
+            workResult = work.get();
+        } finally {
+            MDC.remove(MDC_KEY);
+            for (Logger logger : loggers) {
+                logger.detachAppender(appender);
+                logger.setLevel(previousLevels.get(logger.getName()));
+            }
+            appender.stop();
+        }
+
+        List<AuditedQuery> results = new ArrayList<>();
+        for (String statement : collectStatements(appender.list, marker)) {
+            results.add(new AuditedQuery(statement, explain(session, statement)));
+        }
+        return new AuditResult<>(workResult, results);
+    }
+
+    /** Distinct, non-internal statements from this thread's captured "query execute" events, in execution order. */
+    private static Set<String> collectStatements(List<ILoggingEvent> events, String marker) {
+        Set<String> statements = new LinkedHashSet<>();
+        for (ILoggingEvent event : events) {
+            if (marker.equals(event.getMDCPropertyMap().get(MDC_KEY))) {
+                String message = event.getFormattedMessage();
+                if (message.startsWith(EXECUTE_PREFIX)) {
+                    String statement = message.substring(EXECUTE_PREFIX.length()).trim();
+                    if (!statement.contains(INTERNAL_MARKER)) {
+                        statements.add(statement);
+                    }
+                }
+            }
+        }
+        return statements;
+    }
+
+    /**
+     * EXPLAIN a captured statement in its own language and return the plan Oak chose. Oak normally logs executed
+     * statements as JCR-SQL2 (it converts XPath internally), but AEM's QueryBuilder logs XPath, so the language is
+     * detected rather than assumed — and the reported statement/plan are then in whatever language Oak executed.
+     */
+    private static String explain(Session session, String statement) {
+        String language = isSql2(statement) ? Query.JCR_SQL2 : Query.XPATH;
+        try {
+            return session.getWorkspace().getQueryManager()
+                    .createQuery("explain " + statement, language)
+                    .execute().getRows().nextRow().getValue("plan").getString();
+        } catch (Exception e) {
+            LOG.warn("could not explain {} query: {}", language, statement, e);
+            return "explain failed: " + e.getMessage();
+        }
+    }
+
+    /** JCR-SQL2 statements start with select/explain/measure; anything else (e.g. {@code /jcr:root...}) is XPath. */
+    private static boolean isSql2(String statement) {
+        String trimmed = statement.trim();
+        return trimmed.regionMatches(true, 0, "select", 0, 6)
+                || trimmed.regionMatches(true, 0, "explain", 0, 7)
+                || trimmed.regionMatches(true, 0, "measure", 0, 7);
+    }
+}

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/spi/AuditResult.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/spi/AuditResult.java
@@ -1,0 +1,34 @@
+package be.orbinson.aem.groovy.console.queryaudit.spi;
+
+import java.util.List;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * Outcome of {@link QueryAuditService#audit}: the value the audited work produced, plus the queries it executed and
+ * the Oak plan chosen for each. Bundling the work's result here lets callers avoid a mutable holder when they need
+ * both the result and the audit.
+ *
+ * @param <T> type of value the audited work produced
+ */
+@ProviderType
+public final class AuditResult<T> {
+
+    private final T result;
+    private final List<AuditedQuery> queries;
+
+    public AuditResult(T result, List<AuditedQuery> queries) {
+        this.result = result;
+        this.queries = queries;
+    }
+
+    /** The value returned by the audited work (may be {@code null} if the work produced none). */
+    public T getResult() {
+        return result;
+    }
+
+    /** One entry per distinct query the work executed, in execution order. */
+    public List<AuditedQuery> getQueries() {
+        return queries;
+    }
+}

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/spi/AuditedQuery.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/spi/AuditedQuery.java
@@ -1,0 +1,40 @@
+package be.orbinson.aem.groovy.console.queryaudit.spi;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/** A JCR query that was executed, with the Oak plan chosen for it on the live instance. */
+@ProviderType
+public final class AuditedQuery {
+
+    private final String statement;
+    private final String plan;
+
+    public AuditedQuery(String statement, String plan) {
+        this.statement = statement;
+        this.plan = plan;
+    }
+
+    public String getStatement() {
+        return statement;
+    }
+
+    public String getPlan() {
+        return plan;
+    }
+
+    /** True when Oak found no covering index and fell back to a traversal. */
+    public boolean isNeedsIndex() {
+        return plan.toLowerCase().contains("traverse");
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("statement", statement);
+        map.put("plan", plan);
+        map.put("needsIndex", isNeedsIndex());
+        return map;
+    }
+}

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/spi/AuditedQuery.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/spi/AuditedQuery.java
@@ -10,15 +10,22 @@ import org.osgi.annotation.versioning.ProviderType;
 public final class AuditedQuery {
 
     private final String statement;
+    private final String language;
     private final String plan;
 
-    public AuditedQuery(String statement, String plan) {
+    public AuditedQuery(String statement, String language, String plan) {
         this.statement = statement;
+        this.language = language;
         this.plan = plan;
     }
 
     public String getStatement() {
         return statement;
+    }
+
+    /** The JCR query language of the statement, e.g. {@code JCR-SQL2} or {@code xpath}. */
+    public String getLanguage() {
+        return language;
     }
 
     public String getPlan() {
@@ -33,6 +40,7 @@ public final class AuditedQuery {
     public Map<String, Object> toMap() {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("statement", statement);
+        map.put("language", language);
         map.put("plan", plan);
         map.put("needsIndex", isNeedsIndex());
         return map;

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/spi/QueryAuditService.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/spi/QueryAuditService.java
@@ -1,0 +1,26 @@
+package be.orbinson.aem.groovy.console.queryaudit.spi;
+
+import java.util.function.Supplier;
+
+import javax.jcr.Session;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * Runs a unit of work and reports, per JCR query it executed, whether the live Oak repository has an index that covers
+ * it. Registered by the (optional) query-audit extension; consumers reference it optionally so they work with or
+ * without the extension installed.
+ */
+@ProviderType
+public interface QueryAuditService {
+
+    /**
+     * Run {@code work}, capturing the queries it executes, and EXPLAIN each against the given session.
+     *
+     * @param session session used to EXPLAIN the captured statements (typically the request's session)
+     * @param work the work to run (e.g. executing a script); its return value is passed through on the result
+     * @param <T> type of value the work produces
+     * @return the work's result together with one audited query per distinct executed statement
+     */
+    <T> AuditResult<T> audit(Session session, Supplier<T> work);
+}

--- a/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/spi/package-info.java
+++ b/extensions/query-audit/src/main/java/be/orbinson/aem/groovy/console/queryaudit/spi/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.versioning.Version("1.0.0")
+package be.orbinson.aem.groovy.console.queryaudit.spi;

--- a/extensions/query-audit/src/main/resources/query-audit-panel.js
+++ b/extensions/query-audit/src/main/resources/query-audit-panel.js
@@ -1,98 +1,123 @@
 /*
- * Query-audit panel for the modern AEM Groovy Console.
+ * Query-audit integration for the modern AEM Groovy Console.
  *
- * Self-contained ES module (no build step, no framework): defines the <query-audit-panel> custom element and
- * registers it in the console's activity rail. The panel POSTs a script to /bin/groovyconsole/query-audit and shows,
- * per JCR query the script runs, whether the live Oak instance has an index that covers it.
+ * Self-contained ES module (no build step, no framework). Registers with the console shell:
+ *
+ *  - a run action "Run with query audit" in the Run button's options menu — POSTs the active script to
+ *    /bin/groovyconsole/query-audit, which executes it while capturing every JCR query it runs
+ *  - a "Query audit" result tab in the output dock (next to Log/Result) rendered by the
+ *    <query-audit-result> custom element, showing per query whether an Oak index covers it
  */
 (() => {
   const ENDPOINT = '/bin/groovyconsole/query-audit';
 
-  const ICON =
-    '<svg viewBox="0 0 18 18" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5">' +
-    '<path d="M2 4h10M2 8h7M2 12h5"/><circle cx="13" cy="12" r="3"/><path d="M15.2 14.2L17 16"/></svg>';
-
-  class QueryAuditPanel extends HTMLElement {
-    connectedCallback() {
-      if (this.dataset.ready) {
-        return;
-      }
-      this.dataset.ready = 'true';
-      this.innerHTML = `
-        <style>
-          .qa { display: flex; flex-direction: column; gap: 12px; padding: 12px; font: 13px/1.4 system-ui, sans-serif; }
-          .qa button { align-self: flex-start; padding: 6px 14px; cursor: pointer; }
-          .qa table { width: 100%; border-collapse: collapse; }
-          .qa th, .qa td { text-align: left; padding: 6px 8px; border-bottom: 1px solid rgba(128,128,128,.3); vertical-align: top; }
-          .qa td.stmt { font-family: monospace; white-space: pre-wrap; word-break: break-word; }
-          .qa .needs { color: #d7373f; font-weight: 600; }
-          .qa .ok { color: #268e6c; font-weight: 600; }
-          .qa .msg { opacity: .8; }
-        </style>
-        <div class="qa">
-          <button type="button">Audit active script</button>
-          <div class="results msg">Runs the script currently in the editor and reports, per JCR query, whether an Oak index covers it.</div>
-        </div>`;
-
-      this._results = this.querySelector('.results');
-      this.querySelector('button').addEventListener('click', () => this._audit());
+  class QueryAuditResult extends HTMLElement {
+    get result() {
+      return this._result;
     }
 
-    async _audit() {
-      const script = (window.GroovyConsole?.getScript?.() ?? '').trim();
-      if (!script) {
-        this._results.className = 'results msg';
-        this._results.textContent = 'The editor is empty — nothing to audit.';
+    set result(value) {
+      if (value === this._result) {
         return;
       }
-
-      this._results.className = 'results msg';
-      this._results.textContent = 'Auditing…';
-
-      try {
-        const response = await fetch(ENDPOINT, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: 'script=' + encodeURIComponent(script),
-        });
-        if (!response.ok) {
-          throw new Error('HTTP ' + response.status);
-        }
-        this._render(await response.json());
-      } catch (e) {
-        this._results.className = 'results msg';
-        this._results.textContent = 'Audit failed: ' + e.message;
-      }
+      this._result = value;
+      this._render(value?.queryAudit);
     }
 
-    _render(report) {
-      if (report.exceptionStackTrace) {
-        this._results.className = 'results msg';
-        this._results.textContent = 'Script failed:\n' + report.exceptionStackTrace;
+    _render(queries) {
+      if (!Array.isArray(queries)) {
+        this.innerHTML = '';
         return;
       }
 
-      const queries = report.queries || [];
-      if (!queries.length) {
-        this._results.className = 'results msg';
-        this._results.textContent = 'The script executed no JCR queries.';
-        return;
-      }
+      const needing = queries.filter((query) => query.needsIndex).length;
+      const summary = !queries.length
+        ? 'The script executed no JCR queries.'
+        : needing
+          ? `${queries.length} ${plural(queries.length, 'query', 'queries')} — ${needing} not covered by an Oak index`
+          : `All ${queries.length} ${plural(queries.length, 'query is', 'queries are')} covered by an Oak index`;
 
-      this._results.className = 'results';
       const rows = queries
         .map(
-          (q) =>
-            `<tr><td class="${q.needsIndex ? 'needs' : 'ok'}">${q.needsIndex ? 'needs index' : 'indexed'}</td>` +
-            `<td class="stmt">${escapeHtml(q.statement)}</td>` +
-            `<td class="stmt">${escapeHtml(q.plan)}</td></tr>`
+          (query) => `
+            <div class="qa-row">
+              <span class="qa-badge ${query.needsIndex ? 'qa-needs' : 'qa-ok'}">
+                ${query.needsIndex ? 'needs index' : 'indexed'}
+              </span>
+              <div class="qa-detail">
+                <code class="qa-statement">${escapeHtml(query.statement)}</code>
+                <div class="qa-meta">
+                  ${query.language ? `<span class="qa-lang">${escapeHtml(displayLanguage(query.language))}</span>` : ''}
+                  <details class="qa-plan">
+                    <summary>Oak plan</summary>
+                    <pre>${highlightTraverse(escapeHtml(query.plan))}</pre>
+                  </details>
+                </div>
+              </div>
+            </div>`
         )
         .join('');
-      this._results.innerHTML =
-        '<table><thead><tr><th>Index</th><th>Query</th><th>Oak plan</th></tr></thead><tbody>' +
-        rows +
-        '</tbody></table>';
+
+      this.innerHTML = `
+        <style>
+          /* match the dock's built-in tabs: .gc-dock-pre pads 10px 14px inside the unpadded dock body */
+          query-audit-result { display: block; padding: 10px 14px; font-size: 13px; }
+          query-audit-result .qa-summary { margin: 0 0 8px; font-weight: 600; }
+          query-audit-result .qa-summary.qa-warn { color: var(--spectrum-negative-content-color-default, #d7373f); }
+          query-audit-result .qa-summary.qa-good { color: var(--spectrum-positive-content-color-default, #268e6c); }
+          query-audit-result .qa-row {
+            display: flex; align-items: flex-start; gap: 10px;
+            padding: 8px 0; border-top: 1px solid var(--spectrum-gray-200, rgba(128, 128, 128, 0.25));
+          }
+          query-audit-result .qa-badge {
+            flex: none; box-sizing: border-box; min-width: 92px; margin-top: 1px; padding: 2px 8px;
+            border-radius: 10px; text-align: center;
+            font-size: 11px; font-weight: 700; white-space: nowrap; color: #fff;
+          }
+          query-audit-result .qa-needs { background: var(--spectrum-negative-background-color-default, #d7373f); }
+          query-audit-result .qa-ok { background: var(--spectrum-positive-background-color-default, #268e6c); }
+          query-audit-result .qa-detail { min-width: 0; flex: 1; }
+          query-audit-result .qa-statement {
+            display: block; font-family: var(--spectrum-code-font-family-stack, ui-monospace, Menlo, monospace);
+            font-size: 12px; white-space: pre-wrap; word-break: break-word;
+          }
+          query-audit-result .qa-meta { display: flex; align-items: baseline; gap: 10px; margin-top: 4px; }
+          query-audit-result .qa-lang {
+            flex: none; padding: 1px 6px; border-radius: 4px;
+            border: 1px solid var(--spectrum-gray-300, rgba(128, 128, 128, 0.4));
+            font-size: 10px; font-weight: 600; letter-spacing: 0.3px; opacity: 0.75;
+          }
+          query-audit-result .qa-plan { flex: 1; min-width: 0; }
+          query-audit-result .qa-plan summary { cursor: pointer; font-size: 12px; opacity: 0.75; }
+          query-audit-result .qa-plan pre {
+            margin: 4px 0 0; padding: 6px 10px; border-radius: 0 4px 4px 0;
+            border-left: 3px solid var(--spectrum-gray-300, rgba(128, 128, 128, 0.4));
+            background: var(--spectrum-gray-100, rgba(128, 128, 128, 0.12));
+            font-family: var(--spectrum-code-font-family-stack, ui-monospace, Menlo, monospace);
+            font-size: 12px; white-space: pre-wrap; word-break: break-word;
+          }
+          query-audit-result .qa-plan mark {
+            background: transparent; font-weight: 700;
+            color: var(--spectrum-negative-content-color-default, #d7373f);
+          }
+        </style>
+        <div class="qa-summary ${!queries.length ? '' : needing ? 'qa-warn' : 'qa-good'}">${summary}</div>
+        ${rows}`;
     }
+  }
+
+  function plural(count, singular, pluralForm) {
+    return count === 1 ? singular : pluralForm;
+  }
+
+  /** The backend reports JCR language constants ("JCR-SQL2", "xpath"); prettify the lowercase ones. */
+  function displayLanguage(language) {
+    return language === 'xpath' ? 'XPath' : language;
+  }
+
+  /** Emphasize the traversal marker inside an (already escaped) Oak plan. */
+  function highlightTraverse(escapedPlan) {
+    return escapedPlan.replace(/traverse/gi, (match) => `<mark>${match}</mark>`);
   }
 
   function escapeHtml(value) {
@@ -102,16 +127,44 @@
       .replaceAll('>', '&gt;');
   }
 
-  if (!customElements.get('query-audit-panel')) {
-    customElements.define('query-audit-panel', QueryAuditPanel);
+  /** Run the script through the query-audit endpoint; the report becomes the console's run result. */
+  async function runWithQueryAudit({ script, data }) {
+    const body = new URLSearchParams({ script, data: data ?? '' });
+    const response = await fetch(ENDPOINT, { method: 'POST', body });
+    if (!response.ok) {
+      throw new Error('HTTP ' + response.status);
+    }
+    const report = await response.json();
+    if (report.error) {
+      throw new Error(report.error);
+    }
+    return {
+      result: report.result,
+      output: report.output,
+      exceptionStackTrace: report.exceptionStackTrace,
+      runningTime: report.runningTime,
+      queryAudit: report.queries || [],
+    };
   }
 
-  if (window.GroovyConsole && typeof window.GroovyConsole.registerPanel === 'function') {
-    window.GroovyConsole.registerPanel({
+  if (!customElements.get('query-audit-result')) {
+    customElements.define('query-audit-result', QueryAuditResult);
+  }
+
+  const console_ = window.GroovyConsole;
+  if (typeof console_?.registerRunAction === 'function' && typeof console_?.registerRunResultTab === 'function') {
+    console_.registerRunAction({
       id: 'query-audit',
-      title: 'Query audit',
-      element: 'query-audit-panel',
-      iconHtml: ICON,
+      label: 'Run with query audit',
+      run: runWithQueryAudit,
     });
+    console_.registerRunResultTab({
+      id: 'query-audit',
+      label: 'Query audit',
+      element: 'query-audit-result',
+      isRelevant: (result) => Array.isArray(result?.queryAudit),
+    });
+  } else {
+    console.warn('[query-audit] this console version does not support run actions — update the AEM Groovy Console.');
   }
 })();

--- a/extensions/query-audit/src/main/resources/query-audit-panel.js
+++ b/extensions/query-audit/src/main/resources/query-audit-panel.js
@@ -31,11 +31,18 @@
       }
 
       const needing = queries.filter((query) => query.needsIndex).length;
-      const summary = !queries.length
-        ? 'The script executed no JCR queries.'
-        : needing
-          ? `${queries.length} ${plural(queries.length, 'query', 'queries')} — ${needing} not covered by an Oak index`
-          : `All ${queries.length} ${plural(queries.length, 'query is', 'queries are')} covered by an Oak index`;
+
+      let summary;
+      let summaryClass = '';
+      if (!queries.length) {
+        summary = 'The script executed no JCR queries.';
+      } else if (needing) {
+        summary = `${queries.length} ${plural(queries.length, 'query', 'queries')} — ${needing} not covered by an Oak index`;
+        summaryClass = 'qa-warn';
+      } else {
+        summary = `All ${queries.length} ${plural(queries.length, 'query is', 'queries are')} covered by an Oak index`;
+        summaryClass = 'qa-good';
+      }
 
       const rows = queries
         .map(
@@ -101,7 +108,7 @@
             color: var(--spectrum-negative-content-color-default, #d7373f);
           }
         </style>
-        <div class="qa-summary ${!queries.length ? '' : needing ? 'qa-warn' : 'qa-good'}">${summary}</div>
+        <div class="qa-summary ${summaryClass}">${summary}</div>
         ${rows}`;
     }
   }

--- a/extensions/query-audit/src/main/resources/query-audit-panel.js
+++ b/extensions/query-audit/src/main/resources/query-audit-panel.js
@@ -1,0 +1,117 @@
+/*
+ * Query-audit panel for the modern AEM Groovy Console.
+ *
+ * Self-contained ES module (no build step, no framework): defines the <query-audit-panel> custom element and
+ * registers it in the console's activity rail. The panel POSTs a script to /bin/groovyconsole/query-audit and shows,
+ * per JCR query the script runs, whether the live Oak instance has an index that covers it.
+ */
+(() => {
+  const ENDPOINT = '/bin/groovyconsole/query-audit';
+
+  const ICON =
+    '<svg viewBox="0 0 18 18" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5">' +
+    '<path d="M2 4h10M2 8h7M2 12h5"/><circle cx="13" cy="12" r="3"/><path d="M15.2 14.2L17 16"/></svg>';
+
+  class QueryAuditPanel extends HTMLElement {
+    connectedCallback() {
+      if (this.dataset.ready) {
+        return;
+      }
+      this.dataset.ready = 'true';
+      this.innerHTML = `
+        <style>
+          .qa { display: flex; flex-direction: column; gap: 12px; padding: 12px; font: 13px/1.4 system-ui, sans-serif; }
+          .qa button { align-self: flex-start; padding: 6px 14px; cursor: pointer; }
+          .qa table { width: 100%; border-collapse: collapse; }
+          .qa th, .qa td { text-align: left; padding: 6px 8px; border-bottom: 1px solid rgba(128,128,128,.3); vertical-align: top; }
+          .qa td.stmt { font-family: monospace; white-space: pre-wrap; word-break: break-word; }
+          .qa .needs { color: #d7373f; font-weight: 600; }
+          .qa .ok { color: #268e6c; font-weight: 600; }
+          .qa .msg { opacity: .8; }
+        </style>
+        <div class="qa">
+          <button type="button">Audit active script</button>
+          <div class="results msg">Runs the script currently in the editor and reports, per JCR query, whether an Oak index covers it.</div>
+        </div>`;
+
+      this._results = this.querySelector('.results');
+      this.querySelector('button').addEventListener('click', () => this._audit());
+    }
+
+    async _audit() {
+      const script = (window.GroovyConsole?.getScript?.() ?? '').trim();
+      if (!script) {
+        this._results.className = 'results msg';
+        this._results.textContent = 'The editor is empty — nothing to audit.';
+        return;
+      }
+
+      this._results.className = 'results msg';
+      this._results.textContent = 'Auditing…';
+
+      try {
+        const response = await fetch(ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: 'script=' + encodeURIComponent(script),
+        });
+        if (!response.ok) {
+          throw new Error('HTTP ' + response.status);
+        }
+        this._render(await response.json());
+      } catch (e) {
+        this._results.className = 'results msg';
+        this._results.textContent = 'Audit failed: ' + e.message;
+      }
+    }
+
+    _render(report) {
+      if (report.exceptionStackTrace) {
+        this._results.className = 'results msg';
+        this._results.textContent = 'Script failed:\n' + report.exceptionStackTrace;
+        return;
+      }
+
+      const queries = report.queries || [];
+      if (!queries.length) {
+        this._results.className = 'results msg';
+        this._results.textContent = 'The script executed no JCR queries.';
+        return;
+      }
+
+      this._results.className = 'results';
+      const rows = queries
+        .map(
+          (q) =>
+            `<tr><td class="${q.needsIndex ? 'needs' : 'ok'}">${q.needsIndex ? 'needs index' : 'indexed'}</td>` +
+            `<td class="stmt">${escapeHtml(q.statement)}</td>` +
+            `<td class="stmt">${escapeHtml(q.plan)}</td></tr>`
+        )
+        .join('');
+      this._results.innerHTML =
+        '<table><thead><tr><th>Index</th><th>Query</th><th>Oak plan</th></tr></thead><tbody>' +
+        rows +
+        '</tbody></table>';
+    }
+  }
+
+  function escapeHtml(value) {
+    return String(value == null ? '' : value)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
+  }
+
+  if (!customElements.get('query-audit-panel')) {
+    customElements.define('query-audit-panel', QueryAuditPanel);
+  }
+
+  if (window.GroovyConsole && typeof window.GroovyConsole.registerPanel === 'function') {
+    window.GroovyConsole.registerPanel({
+      id: 'query-audit',
+      title: 'Query audit',
+      element: 'query-audit-panel',
+      iconHtml: ICON,
+    });
+  }
+})();

--- a/it.tests/pom.xml
+++ b/it.tests/pom.xml
@@ -292,6 +292,12 @@
             <type>zip</type>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>aem-groovy-console-query-audit</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Testing -->
         <dependency>
@@ -309,6 +315,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
             <version>4.5.14</version>
             <scope>test</scope>
         </dependency>

--- a/it.tests/src/main/features/groovyconsole-query-audit.json
+++ b/it.tests/src/main/features/groovyconsole-query-audit.json
@@ -1,0 +1,8 @@
+{
+  "bundles":[
+    {
+      "id": "be.orbinson.aem:aem-groovy-console-query-audit:20.0.0-SNAPSHOT",
+      "start-order": "20"
+    }
+  ]
+}

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/IndexDetectionIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/IndexDetectionIT.java
@@ -1,0 +1,134 @@
+package be.orbinson.aem.groovy.console.it;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end index audit against the LIVE instance. Deploys a Groovy script, then runs an audit harness that (1) runs
+ * that script while capturing the JCR queries it executes, and (2) EXPLAINs each against the instance's real Oak
+ * indexes. Demonstrates the goal: verifying that the indexes a migration/report script relies on actually exist on
+ * the target instance — without adding EXPLAIN to the script itself.
+ */
+class IndexDetectionIT {
+
+    private static final int SLING_PORT = Integer.getInteger("HTTP_PORT", 8080);
+    private static final String BASE_URL = "http://localhost:" + SLING_PORT;
+    private static final String AUTH_HEADER =
+            "Basic " + Base64.encodeBase64String("admin:admin".getBytes(StandardCharsets.UTF_8));
+
+    private static final String TARGET_PATH = "/var/groovyconsole/it/AuditTarget.groovy";
+    private static final String INDEX_PATH = "/oak:index/auditMarkerIt";
+
+    private static CloseableHttpClient httpClient;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        httpClient = HttpClients.createDefault();
+        waitForReadiness(300);
+        deployTargetScript();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        SlingContent.delete(httpClient, BASE_URL, AUTH_HEADER, TARGET_PATH);
+        SlingContent.delete(httpClient, BASE_URL, AUTH_HEADER, INDEX_PATH);
+        if (httpClient != null) {
+            httpClient.close();
+        }
+    }
+
+    @Test
+    void detectsMissingIndexForTheScriptThenCoverageAfterCreatingIt() throws Exception {
+        // 1. No custom index yet -> the script's query traverses -> the audit flags it as needing an index.
+        JsonObject before = auditedQuery();
+        System.out.println("[index-it] statement   = " + before.get("statement").getAsString());
+        System.out.println("[index-it] plan before  = " + before.get("plan").getAsString());
+        assertTrue(before.get("needsIndex").getAsBoolean(),
+                "the query filters on a non-indexed property, so it should need an index; plan was: "
+                        + before.get("plan").getAsString());
+
+        // 2. Create the property index the script needs.
+        createPropertyIndex();
+
+        // 3. The same script's query is now covered on the live instance.
+        JsonObject after = auditedQuery();
+        System.out.println("[index-it] plan after   = " + after.get("plan").getAsString());
+        assertFalse(after.get("needsIndex").getAsBoolean(),
+                "with the property index installed the query should be covered; plan was: "
+                        + after.get("plan").getAsString());
+    }
+
+    /** Audit the deployed target script via the query-audit servlet; assert one query was audited and return it. */
+    private JsonObject auditedQuery() throws IOException {
+        JsonObject response = post("/bin/groovyconsole/query-audit", param("scriptPath", TARGET_PATH));
+        assertEquals("", response.get("exceptionStackTrace").getAsString(), "audited script failed");
+        JsonArray queries = response.getAsJsonArray("queries");
+        assertEquals(1, queries.size(), "expected exactly one audited query, got: " + queries);
+        return queries.get(0).getAsJsonObject();
+    }
+
+    private static void deployTargetScript() throws IOException {
+        SlingContent.deployFile(httpClient, BASE_URL, AUTH_HEADER, TARGET_PATH, "/scripts/audit-target.groovy");
+    }
+
+    private void createPropertyIndex() throws IOException {
+        JsonObject response = executeScript(SlingContent.read("/scripts/create-audit-index.groovy"));
+        assertEquals("", response.get("exceptionStackTrace").getAsString(), "index creation failed");
+    }
+
+    private static void waitForReadiness(long timeoutSec) {
+        await().atMost(timeoutSec, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .untilAsserted(() -> assertEquals("ready", executeScript("return 'ready'").get("result").getAsString()));
+    }
+
+    private static JsonObject executeScript(String script) throws IOException {
+        return post("/bin/groovyconsole/post", param("script", script));
+    }
+
+    private static BasicNameValuePair param(String name, String value) {
+        return new BasicNameValuePair(name, value);
+    }
+
+    private static JsonObject post(String path, BasicNameValuePair... params) throws IOException {
+        HttpPost httpPost = new HttpPost(BASE_URL + path);
+        List<BasicNameValuePair> list = new ArrayList<>();
+        for (BasicNameValuePair p : params) {
+            list.add(p);
+        }
+        httpPost.setEntity(new UrlEncodedFormEntity(list, StandardCharsets.UTF_8));
+        httpPost.addHeader("Authorization", AUTH_HEADER);
+        httpPost.addHeader("Connection", "close");
+        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+            if (response.getStatusLine().getStatusCode() != 200) {
+                return null;
+            }
+            String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            return JsonParser.parseString(body).getAsJsonObject();
+        }
+    }
+}

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/MigrationIndexAuditIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/MigrationIndexAuditIT.java
@@ -1,0 +1,130 @@
+package be.orbinson.aem.groovy.console.it;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the optional query-audit integration in the migration extension: a migration run started with
+ * {@code measureIndexUsage=true} reports, per script, whether its queries are backed by an Oak index — the CI
+ * validation the migration extension enables when the (optional) query-audit extension is installed.
+ */
+class MigrationIndexAuditIT {
+
+    private static final int SLING_PORT = Integer.getInteger("HTTP_PORT", 8080);
+    private static final String BASE_URL = "http://localhost:" + SLING_PORT;
+    private static final String AUTH_HEADER =
+            "Basic " + Base64.encodeBase64String("admin:admin".getBytes(StandardCharsets.UTF_8));
+
+    // A migration script under the migration extension's default scripts base path.
+    private static final String SCRIPT_NAME = "it-index-audit.groovy";
+    private static final String SCRIPT_PATH = "/conf/groovyconsole/scripts/migration/" + SCRIPT_NAME;
+
+    private static CloseableHttpClient httpClient;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        httpClient = HttpClients.createDefault();
+        waitForReadiness(300);
+        deployMigrationScript();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        SlingContent.delete(httpClient, BASE_URL, AUTH_HEADER, SCRIPT_PATH);
+        if (httpClient != null) {
+            httpClient.close();
+        }
+    }
+
+    @Test
+    void migrationRunReportsIndexUsagePerScript() throws Exception {
+        JsonObject run = post("/bin/groovyconsole/migration",
+                param("measureIndexUsage", "true"));
+        assertNotNull(run, "no response from migration run");
+
+        JsonArray results = run.getAsJsonArray("results");
+        assertNotNull(results, "migration run had no results: " + run);
+
+        JsonObject scriptResult = null;
+        for (int i = 0; i < results.size(); i++) {
+            JsonObject r = results.get(i).getAsJsonObject();
+            if (r.get("scriptPath").getAsString().endsWith(SCRIPT_NAME)) {
+                scriptResult = r;
+                break;
+            }
+        }
+        assertNotNull(scriptResult, "audited migration script not found in results: " + results);
+
+        JsonArray queryAudit = scriptResult.getAsJsonArray("queryAudit");
+        assertNotNull(queryAudit, "expected a queryAudit on the script result: " + scriptResult);
+        assertEquals(1, queryAudit.size(), "expected one audited query, got: " + queryAudit);
+
+        JsonObject query = queryAudit.get(0).getAsJsonObject();
+        System.out.println("[migration-index-it] statement = " + query.get("statement").getAsString());
+        System.out.println("[migration-index-it] plan      = " + query.get("plan").getAsString());
+        assertTrue(query.get("needsIndex").getAsBoolean(),
+                "the migration script's query filters on a non-indexed property, so it should be flagged; plan was: "
+                        + query.get("plan").getAsString());
+    }
+
+    private static void deployMigrationScript() throws IOException {
+        SlingContent.deployFile(httpClient, BASE_URL, AUTH_HEADER, SCRIPT_PATH, "/scripts/migration-index-audit.groovy");
+    }
+
+    private static JsonObject console(String script) throws IOException {
+        return post("/bin/groovyconsole/post", param("script", script));
+    }
+
+    private static void waitForReadiness(long timeoutSec) {
+        await().atMost(timeoutSec, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .untilAsserted(() -> assertEquals("ready", console("return 'ready'").get("result").getAsString()));
+    }
+
+    private static BasicNameValuePair param(String name, String value) {
+        return new BasicNameValuePair(name, value);
+    }
+
+    private static JsonObject post(String path, BasicNameValuePair... params) throws IOException {
+        HttpPost httpPost = new HttpPost(BASE_URL + path);
+        List<BasicNameValuePair> list = new ArrayList<>();
+        for (BasicNameValuePair p : params) {
+            list.add(p);
+        }
+        httpPost.setEntity(new UrlEncodedFormEntity(list, StandardCharsets.UTF_8));
+        httpPost.addHeader("Authorization", AUTH_HEADER);
+        httpPost.addHeader("Connection", "close");
+        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+            int status = response.getStatusLine().getStatusCode();
+            String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+            if (status != 200) {
+                return null;
+            }
+            return JsonParser.parseString(body).getAsJsonObject();
+        }
+    }
+}

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/SlingContent.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/SlingContent.java
@@ -1,0 +1,86 @@
+package be.orbinson.aem.groovy.console.it;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Scanner;
+
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+
+/**
+ * Test helper for provisioning repository content over HTTP via the SlingPostServlet, so integration tests can
+ * reference real script files from {@code src/test/resources} instead of building scripts from concatenated strings.
+ */
+final class SlingContent {
+
+    private SlingContent() {
+    }
+
+    /**
+     * Deploy a classpath resource as an {@code nt:file} at {@code jcrPath} using a SlingPostServlet file upload
+     * (multipart POST to the parent, part named after the file — exactly what {@code curl -F name=@file parent/} does).
+     *
+     * @param jcrPath absolute path of the resulting nt:file, e.g. {@code /var/groovyconsole/it/AuditTarget.groovy}
+     * @param classpathResource resource on the test classpath, e.g. {@code /scripts/audit-target.groovy}
+     */
+    static void deployFile(CloseableHttpClient client, String baseUrl, String authHeader,
+                           String jcrPath, String classpathResource) throws IOException {
+        byte[] content = read(classpathResource).getBytes(StandardCharsets.UTF_8);
+        int slash = jcrPath.lastIndexOf('/');
+        String parent = jcrPath.substring(0, slash);
+        String name = jcrPath.substring(slash + 1);
+
+        // POST to the parent WITHOUT a trailing slash: a trailing slash triggers SlingPostServlet's auto node-name
+        // generation, which would nest the file under a generated node instead of creating it at `parent/name`.
+        HttpPost post = new HttpPost(baseUrl + parent);
+        post.addHeader("Authorization", authHeader);
+        post.addHeader("Connection", "close");
+        post.setEntity(MultipartEntityBuilder.create()
+                .addBinaryBody(name, content, ContentType.create("application/octet-stream"), name)
+                .build());
+
+        execute(client, post, "deploy " + classpathResource + " to " + jcrPath);
+    }
+
+    /** Remove a node via the SlingPostServlet {@code :operation=delete}. No-op if the node does not exist. */
+    static void delete(CloseableHttpClient client, String baseUrl, String authHeader, String jcrPath) throws IOException {
+        HttpPost post = new HttpPost(baseUrl + jcrPath);
+        post.addHeader("Authorization", authHeader);
+        post.addHeader("Connection", "close");
+        post.setEntity(new UrlEncodedFormEntity(
+                Collections.singletonList(new BasicNameValuePair(":operation", "delete")), StandardCharsets.UTF_8));
+        execute(client, post, "delete " + jcrPath);
+    }
+
+    /** Read a text resource from the test classpath. */
+    static String read(String classpathResource) {
+        try (InputStream stream = SlingContent.class.getResourceAsStream(classpathResource)) {
+            if (stream == null) {
+                throw new IOException("test resource not found on classpath: " + classpathResource);
+            }
+            try (Scanner scanner = new Scanner(stream, StandardCharsets.UTF_8.name())) {
+                return scanner.useDelimiter("\\A").hasNext() ? scanner.next() : "";
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void execute(CloseableHttpClient client, HttpPost post, String description) throws IOException {
+        try (CloseableHttpResponse response = client.execute(post)) {
+            int status = response.getStatusLine().getStatusCode();
+            // SlingPostServlet returns 200 (modified) or 201 (created).
+            if (status != 200 && status != 201) {
+                throw new IOException("failed to " + description + " : HTTP " + status);
+            }
+        }
+    }
+}

--- a/it.tests/src/test/resources/scripts/audit-target.groovy
+++ b/it.tests/src/test/resources/scripts/audit-target.groovy
@@ -1,0 +1,3 @@
+// Script under test for IndexDetectionIT: a plain-JCR query on a custom (un-indexed) property, so on the Sling
+// Starter it must traverse until a matching property index is created.
+sql2Query("SELECT * FROM [nt:base] AS n WHERE ISDESCENDANTNODE(n, '/content') AND n.[auditMarker] = 'flagged'")

--- a/it.tests/src/test/resources/scripts/create-audit-index.groovy
+++ b/it.tests/src/test/resources/scripts/create-audit-index.groovy
@@ -1,0 +1,10 @@
+// Creates the Oak property index that covers IndexDetectionIT's target query (propertyNames must be of type NAME).
+def oakIndex = session.getNode('/oak:index')
+if (!oakIndex.hasNode('auditMarkerIt')) {
+    def idx = oakIndex.addNode('auditMarkerIt', 'oak:QueryIndexDefinition')
+    idx.setProperty('type', 'property')
+    idx.setProperty('propertyNames', ['auditMarker'] as String[], javax.jcr.PropertyType.NAME)
+    idx.setProperty('reindex', true)
+    session.save()
+}
+return 'created'

--- a/it.tests/src/test/resources/scripts/migration-index-audit.groovy
+++ b/it.tests/src/test/resources/scripts/migration-index-audit.groovy
@@ -1,0 +1,3 @@
+// Migration script for MigrationIndexAuditIT: its query filters on a non-indexed property, so it must traverse and
+// is therefore flagged as needing an index when the migration runs with measureIndexUsage=true.
+sql2Query("SELECT * FROM [nt:base] AS n WHERE ISDESCENDANTNODE(n, '/content') AND n.[migrationAuditMarker] = 'x'")

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -50,6 +50,14 @@
     </build>
 
     <dependencies>
+        <!-- MUST be first: sling-mock-oak bundles its own Oak; declaring it before uber-jar makes that Oak win on
+             the classpath (uber-jar bundles an older, conflicting Oak). Required for JCR_OAK index-detection tests. -->
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>be.orbinson.aem</groupId>
             <artifactId>aem-groovy-console-bundle</artifactId>
@@ -76,6 +84,20 @@
         <dependency>
             <groupId>be.orbinson.aem</groupId>
             <artifactId>aem-groovy-console-test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Logback backend: the query-audit service captures Oak's query log through it to detect traversals. -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.13</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- The real query-audit service, used by the index-audit test instead of a test-local reimplementation. -->
+        <dependency>
+            <groupId>be.orbinson.aem</groupId>
+            <artifactId>aem-groovy-console-query-audit</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/ui.content/src/main/content/jcr_root/conf/groovyconsole/scripts/samples/AuditQueryIndexes.groovy
+++ b/ui.content/src/main/content/jcr_root/conf/groovyconsole/scripts/samples/AuditQueryIndexes.groovy
@@ -1,0 +1,31 @@
+/*
+ * Demonstrates the query-audit extension on any Sling or AEM instance.
+ *
+ * Run this with "Run with query audit" (the arrow next to the Run button, available when the
+ * query-audit extension is installed). The Query audit tab then shows, per JCR query the script
+ * executed, whether an Oak index on THIS instance covers it:
+ *
+ *  - the jcr:uuid lookup is answered by the built-in /oak:index/uuid property index -> "indexed"
+ *  - no index covers the arbitrary demoMarker property, so both filters on it (one JCR-SQL2,
+ *    one XPath) force Oak to traverse every node under /content -> "needs index"
+ */
+
+def queryManager = session.workspace.queryManager
+
+def indexed = queryManager.createQuery(
+    "SELECT * FROM [mix:referenceable] AS node WHERE node.[jcr:uuid] = '00000000-0000-0000-0000-000000000000'",
+    "JCR-SQL2").execute()
+
+println "uuid lookup returned ${indexed.nodes.size()} node(s)"
+
+def unindexed = queryManager.createQuery(
+    "SELECT * FROM [nt:base] AS node WHERE ISDESCENDANTNODE(node, '/content') AND node.[demoMarker] = 'audit-me'",
+    "JCR-SQL2").execute()
+
+println "demoMarker filter (JCR-SQL2) returned ${unindexed.nodes.size()} node(s)"
+
+def xpath = queryManager.createQuery(
+    "/jcr:root/content//*[@demoMarker = 'audit-me']",
+    "xpath").execute()
+
+println "demoMarker filter (XPath) returned ${xpath.nodes.size()} node(s)"

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/migrations/FlagSectionPagesIndexAuditTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/migrations/FlagSectionPagesIndexAuditTest.java
@@ -1,0 +1,99 @@
+package be.orbinson.aem.groovy.console.migrations;
+
+import static be.orbinson.aem.groovy.console.migrations.FlagSectionPagesMigrationTest.TEMPLATE;
+import static be.orbinson.aem.groovy.console.migrations.FlagSectionPagesMigrationTest.migration;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.jcr.Node;
+import javax.jcr.PropertyType;
+import javax.jcr.Session;
+
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import be.orbinson.aem.groovy.console.queryaudit.QueryPlanAuditor;
+import be.orbinson.aem.groovy.console.queryaudit.spi.AuditedQuery;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+/**
+ * Detects which Oak indexes the FlagSectionPages migration needs, by running it through the real query-audit service
+ * ({@link QueryPlanAuditor}) against real Oak (JCR_OAK) and inspecting the plan Oak chose for each query. Demonstrates
+ * both directions:
+ * <ul>
+ *   <li>with no custom index, the migration's query traverses -> the test lists it as needing an index;</li>
+ *   <li>after installing a cq:template index, the same query is covered -> no query traverses.</li>
+ * </ul>
+ */
+@ExtendWith(AemContextExtension.class)
+class FlagSectionPagesIndexAuditTest {
+
+    private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_OAK)
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void listsTheIndexesTheMigrationNeeds() {
+        seedContent();
+
+        List<AuditedQuery> queries = audit();
+
+        List<AuditedQuery> needingIndex = queries.stream()
+                .filter(AuditedQuery::isNeedsIndex)
+                .collect(Collectors.toList());
+
+        System.out.println("[audit] queries the migration runs: " + queries.size());
+        needingIndex.forEach(q -> System.out.println(
+                "[audit] NEEDS INDEX: " + q.getStatement() + "\n           plan: " + q.getPlan()));
+
+        // The migration filters on cq:template, so without an index that query must traverse.
+        assertTrue(needingIndex.stream().anyMatch(q -> q.getStatement().contains("cq:template")),
+                "expected the cq:template query to require an index");
+    }
+
+    @Test
+    void queriesAreCoveredOnceTheIndexDefinitionsAreInstalled() throws Exception {
+        installPropertyIndex("cqTemplate", "cq:template");
+        seedContent();
+
+        List<AuditedQuery> queries = audit();
+
+        queries.forEach(q -> System.out.println("[audit] " + (q.isNeedsIndex() ? "TRAVERSE" : "INDEXED ")
+                + " | " + q.getPlan()));
+
+        assertFalse(queries.isEmpty(), "expected at least one query to be audited");
+        assertTrue(queries.stream().noneMatch(AuditedQuery::isNeedsIndex),
+                "with the cq:template index installed no query should traverse");
+    }
+
+    /** Run the migration through the real query-audit service and return the queries it executed. */
+    private List<AuditedQuery> audit() {
+        Session session = context.resourceResolver().adaptTo(Session.class);
+        return new QueryPlanAuditor()
+                .audit(session, () -> GroovyConsole.runScript(context, migration()))
+                .getQueries();
+    }
+
+    private void seedContent() {
+        context.create().page("/content/we-retail", "otherTemplate", "We Retail");
+        context.create().page("/content/we-retail/products", TEMPLATE, "Products");
+    }
+
+    /** Installs an Oak property index. propertyNames must be of type NAME for Oak to use it. */
+    private void installPropertyIndex(String name, String property) throws Exception {
+        Session session = context.resourceResolver().adaptTo(Session.class);
+        Node index = session.getNode("/oak:index").addNode(name, "oak:QueryIndexDefinition");
+        index.setProperty("type", "property");
+        index.setProperty("propertyNames", new String[]{property}, PropertyType.NAME);
+        index.setProperty("reindex", true);
+        session.save();
+    }
+}

--- a/ui.content/src/test/java/be/orbinson/aem/groovy/console/migrations/FlagSectionPagesMigrationTest.java
+++ b/ui.content/src/test/java/be/orbinson/aem/groovy/console/migrations/FlagSectionPagesMigrationTest.java
@@ -1,0 +1,62 @@
+package be.orbinson.aem.groovy.console.migrations;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import be.orbinson.aem.groovy.console.testing.GroovyConsole;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+/**
+ * Functional test for the FlagSectionPages migration: it queries for section pages and flags them. Runs against real
+ * Oak (JCR_OAK) because the migration relies on a JCR-SQL2 query, which the JCR mock does not execute.
+ */
+@ExtendWith(AemContextExtension.class)
+class FlagSectionPagesMigrationTest {
+
+    static final String TEMPLATE = "/conf/we-retail/settings/wcm/templates/section-page";
+
+    private final AemContext context = new AemContextBuilder(ResourceResolverType.JCR_OAK)
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void flagsSectionPages() {
+        context.create().page("/content/we-retail", "otherTemplate", "We Retail");
+        context.create().page("/content/we-retail/products", TEMPLATE, "Products");
+        context.create().page("/content/we-retail/about", "otherTemplate", "About");
+
+        RunScriptResponse response = GroovyConsole.runScript(context, migration());
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+        assertTrue(reviewed("/content/we-retail/products"), "section page should be flagged");
+        assertFalse(reviewed("/content/we-retail/about"), "non-section page should not be flagged");
+    }
+
+    private boolean reviewed(String pagePath) {
+        return context.resourceResolver().getResource(pagePath + "/jcr:content")
+                .getValueMap().get("reviewed", false);
+    }
+
+    static String migration() {
+        try {
+            return IOUtils.toString(
+                    FlagSectionPagesMigrationTest.class.getResourceAsStream("/migrations/FlagSectionPages.groovy"),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/ui.content/src/test/resources/migrations/FlagSectionPages.groovy
+++ b/ui.content/src/test/resources/migrations/FlagSectionPages.groovy
@@ -1,0 +1,11 @@
+// Migration: flag every we-retail section page for review.
+// Queries by cq:template (over nt:base), so in a real repository it needs a property/lucene index on cq:template.
+def statement = "SELECT * FROM [nt:base] AS content " +
+        "WHERE ISDESCENDANTNODE(content, '/content/we-retail') " +
+        "AND content.[cq:template] = '/conf/we-retail/settings/wcm/templates/section-page'"
+
+sql2Query(statement).each { node ->
+    node.set("reviewed", true)
+}
+
+save()

--- a/ui.frontend/src/components/gc-app-bar.ts
+++ b/ui.frontend/src/components/gc-app-bar.ts
@@ -2,17 +2,23 @@ import { html, LitElement, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { config } from '../config';
 import { StoreController } from '../state/store';
+import { getRunActions, onExtensionsChanged } from '../extensions/registry';
+import type { ConsoleRunActionExtension } from '../extensions/registry';
 
 /** Top app bar: brand, current script name, primary Run action, theme switch, and a file menu. */
 @customElement('gc-app-bar')
 export class GcAppBar extends LitElement {
   private store = new StoreController(this);
+  private unsubscribeExtensions?: () => void;
 
   @state() private menuOpen = false;
+  @state() private runMenuOpen = false;
+  @state() private runActions: readonly ConsoleRunActionExtension[] = getRunActions();
 
   private outsideClickListener = (event: MouseEvent): void => {
-    if (this.menuOpen && !this.contains(event.target as Node)) {
+    if ((this.menuOpen || this.runMenuOpen) && !this.contains(event.target as Node)) {
       this.menuOpen = false;
+      this.runMenuOpen = false;
     }
   };
 
@@ -23,16 +29,23 @@ export class GcAppBar extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
     window.addEventListener('click', this.outsideClickListener);
+    this.unsubscribeExtensions = onExtensionsChanged(() => (this.runActions = [...getRunActions()]));
   }
 
   disconnectedCallback(): void {
     window.removeEventListener('click', this.outsideClickListener);
+    this.unsubscribeExtensions?.();
     super.disconnectedCallback();
   }
 
   private emit(name: string): void {
     this.menuOpen = false;
     this.dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true }));
+  }
+
+  private emitRunAction(actionId: string): void {
+    this.runMenuOpen = false;
+    this.dispatchEvent(new CustomEvent('gc-run-action', { detail: { actionId }, bubbles: true, composed: true }));
   }
 
   protected render() {
@@ -46,11 +59,47 @@ export class GcAppBar extends LitElement {
         </span>
 
         <div class="gc-app-bar-actions">
-          <sp-button variant="accent" size="m" ?disabled=${running} @click=${() => this.emit('gc-run')}>
-            ${running
-              ? html`<sp-progress-circle indeterminate size="s" slot="icon"></sp-progress-circle> Running…`
-              : 'Run'}
-          </sp-button>
+          <div class="gc-run-group">
+            <sp-button variant="accent" size="m" ?disabled=${running} @click=${() => this.emit('gc-run')}>
+              ${running
+                ? html`<sp-progress-circle indeterminate size="s" slot="icon"></sp-progress-circle> Running…`
+                : 'Run'}
+            </sp-button>
+            ${this.runActions.length
+              ? html`
+                  <div class="gc-overflow">
+                    <sp-button
+                      class="gc-run-more"
+                      variant="accent"
+                      size="m"
+                      ?disabled=${running}
+                      aria-label="More run options"
+                      aria-haspopup="true"
+                      aria-expanded=${this.runMenuOpen}
+                      @click=${(event: Event) => {
+                        event.stopPropagation();
+                        this.runMenuOpen = !this.runMenuOpen;
+                      }}
+                    >
+                      ▾
+                    </sp-button>
+                    ${this.runMenuOpen
+                      ? html`
+                          <div class="gc-overflow-menu" role="menu">
+                            ${this.runActions.map(
+                              (action) => html`
+                                <button role="menuitem" @click=${() => this.emitRunAction(action.id)}>
+                                  ${action.label}
+                                </button>
+                              `,
+                            )}
+                          </div>
+                        `
+                      : nothing}
+                  </div>
+                `
+              : nothing}
+          </div>
           ${config.aem && config.distributedExecutionEnabled
             ? html`
                 <sp-button variant="primary" size="m" treatment="outline" ?disabled=${running}

--- a/ui.frontend/src/components/gc-app.ts
+++ b/ui.frontend/src/components/gc-app.ts
@@ -15,7 +15,7 @@ import type { GcSaveDialog } from './gc-save-dialog';
 import type { GcScheduler } from './gc-scheduler';
 import type { GcScriptBrowserDialog } from './gc-script-browser-dialog';
 import type { GcScriptEditor } from './gc-script-editor';
-import { getPanels, initConsoleExtensions, onPanelsChanged } from '../extensions/registry';
+import { getPanels, initConsoleExtensions, onPanelsChanged, setActiveScriptProvider } from '../extensions/registry';
 import type { ConsolePanelExtension } from '../extensions/registry';
 
 /** Built-in drawers use 'history' | 'jobs' | 'help'; extension panels use their registered panel id. */
@@ -119,6 +119,9 @@ export class GcApp extends LitElement {
 
   protected firstUpdated(): void {
     prefetchAssistData();
+
+    // Let extensions read the editor's current script (e.g. the query-audit panel).
+    setActiveScriptProvider(() => this.scriptEditor?.value ?? '');
 
     // Load UI extension modules announced by the backend (ConsoleUiExtensionProvider services).
     initConsoleExtensions();

--- a/ui.frontend/src/components/gc-app.ts
+++ b/ui.frontend/src/components/gc-app.ts
@@ -15,7 +15,7 @@ import type { GcSaveDialog } from './gc-save-dialog';
 import type { GcScheduler } from './gc-scheduler';
 import type { GcScriptBrowserDialog } from './gc-script-browser-dialog';
 import type { GcScriptEditor } from './gc-script-editor';
-import { getPanels, initConsoleExtensions, onPanelsChanged, setActiveScriptProvider } from '../extensions/registry';
+import { getPanels, getRunActions, initConsoleExtensions, onExtensionsChanged, setActiveScriptProvider } from '../extensions/registry';
 import type { ConsolePanelExtension } from '../extensions/registry';
 
 /** Built-in drawers use 'history' | 'jobs' | 'help'; extension panels use their registered panel id. */
@@ -84,7 +84,10 @@ export class GcApp extends LitElement {
     this.addEventListener('gc-toast', ((event: CustomEvent<{ message: string; variant?: 'positive' | 'negative' }>) => {
       store.showToast(event.detail.message, event.detail.variant ?? 'positive');
     }) as EventListener);
-    this.unsubscribePanels = onPanelsChanged(() => (this.extensionPanels = [...getPanels()]));
+    this.addEventListener('gc-run-action', ((event: CustomEvent<{ actionId: string }>) => {
+      void this.executeRunAction(event.detail.actionId);
+    }) as EventListener);
+    this.unsubscribePanels = onExtensionsChanged(() => (this.extensionPanels = [...getPanels()]));
     this.addEventListener('gc-edit-job', ((event: CustomEvent<{ job: ScheduledJob }>) => {
       this.editScheduledJob(event.detail.job);
     }) as EventListener);
@@ -227,6 +230,33 @@ export class GcApp extends LitElement {
           'negative',
         );
       }
+    } finally {
+      this.setRunning(false);
+      window.dispatchEvent(new CustomEvent('gc-refresh-audit'));
+    }
+  }
+
+  /** Execute an extension-registered run action ("Run with query audit" etc.) with the usual run lifecycle. */
+  private async executeRunAction(actionId: string): Promise<void> {
+    const action = getRunActions().find((candidate) => candidate.id === actionId);
+    if (!action || this.store.state.running) {
+      return;
+    }
+
+    const script = this.scriptEditor.value;
+    if (!script.length) {
+      store.showToast('Script is empty.', 'negative');
+      return;
+    }
+
+    store.setState({ result: null });
+    this.setRunning(true);
+
+    try {
+      const result = await action.run({ script, data: this.dataEditor.value });
+      store.setState({ result });
+    } catch {
+      store.showToast(`${action.label} failed. Check error.log file.`, 'negative');
     } finally {
       this.setRunning(false);
       window.dispatchEvent(new CustomEvent('gc-refresh-audit'));

--- a/ui.frontend/src/components/gc-result.ts
+++ b/ui.frontend/src/components/gc-result.ts
@@ -1,9 +1,13 @@
 import { html, LitElement, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import type { RunScriptResponse, TableResult } from '../api/types';
+import { getRunResultTabs, onExtensionsChanged } from '../extensions/registry';
+import type { ConsoleRunResultTabExtension, ExtendedRunResult } from '../extensions/registry';
 import { store, StoreController } from '../state/store';
 
-type DockTab = 'result' | 'log' | 'trace' | 'table';
+/** Built-in tab ids, or the id of an extension-registered result tab. */
+type DockTab = 'result' | 'log' | 'trace' | 'table' | string;
 
 function parseTable(result?: string): TableResult | null {
   if (!result) {
@@ -25,9 +29,28 @@ export class GcResult extends LitElement {
   @state() private selectedTab: DockTab = 'log';
 
   private lastResult: RunScriptResponse | null = null;
+  private unsubscribeExtensions?: () => void;
 
   createRenderRoot(): this {
     return this;
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.unsubscribeExtensions = onExtensionsChanged(() => this.requestUpdate());
+  }
+
+  disconnectedCallback(): void {
+    this.unsubscribeExtensions?.();
+    super.disconnectedCallback();
+  }
+
+  /** Extension result tabs that apply to the given run result (e.g. Query audit after an audited run). */
+  private relevantExtensionTabs(result: RunScriptResponse | null): ConsoleRunResultTabExtension[] {
+    if (!result) {
+      return [];
+    }
+    return getRunResultTabs().filter((tab) => tab.isRelevant(result as ExtendedRunResult));
   }
 
   protected willUpdate(): void {
@@ -35,10 +58,13 @@ export class GcResult extends LitElement {
 
     if (result !== this.lastResult) {
       this.lastResult = result;
-      // Default to the Log (output) tab — it's what's wanted most of the time. Errors still
-      // jump to the trace; tables and the raw result are available as secondary tabs.
+      const extensionTabs = this.relevantExtensionTabs(result);
+      // Default to the Log (output) tab — it's what's wanted most of the time. Errors still jump to the
+      // trace; a relevant extension tab (present only for that extension's run mode) beats the log.
       if (result?.exceptionStackTrace?.length) {
         this.selectedTab = 'trace';
+      } else if (extensionTabs.length) {
+        this.selectedTab = extensionTabs[0].id;
       } else if (result?.output?.length) {
         this.selectedTab = 'log';
       } else if (parseTable(result?.result)) {
@@ -131,6 +157,15 @@ export class GcResult extends LitElement {
       const body = this.querySelector('.gc-dock-body');
       body?.scrollTo({ top: body.scrollHeight });
     }
+
+    // extension result tab: hand the run result to the extension's element (it renders itself)
+    const extensionTab = getRunResultTabs().find((tab) => tab.id === this.selectedTab);
+    if (extensionTab) {
+      const element = this.querySelector(extensionTab.element) as (HTMLElement & { result?: unknown }) | null;
+      if (element && element.result !== this.store.state.result) {
+        element.result = this.store.state.result;
+      }
+    }
   }
 
   protected render() {
@@ -164,14 +199,17 @@ export class GcResult extends LitElement {
     const table = parseTable(response.result);
     const error = !!response.exceptionStackTrace?.length;
 
+    const extensionTabs = this.relevantExtensionTabs(response);
     const tabs: Array<{ id: DockTab; label: string; show: boolean }> = [
       { id: 'log', label: 'Log', show: !!response.output?.length },
       { id: 'result', label: 'Result', show: !table && !!response.result?.length },
       { id: 'table', label: 'Table', show: !!table },
       { id: 'trace', label: 'Trace', show: error },
+      ...extensionTabs.map((tab) => ({ id: tab.id, label: tab.label, show: true })),
     ];
     const visibleTabs = tabs.filter((tab) => tab.show);
     const active = this.activeContent(response);
+    const selectedExtensionTab = extensionTabs.find((tab) => tab.id === this.selectedTab);
 
     return html`
       <div class="gc-dock ${error ? 'gc-dock-error' : ''}">
@@ -205,15 +243,17 @@ export class GcResult extends LitElement {
             : nothing}
         </div>
         <div class="gc-dock-body">
-          ${this.selectedTab === 'table' && table
-            ? this.renderTable(table)
-            : this.selectedTab === 'trace' && active
-              ? this.renderTrace(active.text)
-              : active
-                ? html`<pre class="gc-dock-pre">${active.text}</pre>`
-                : visibleTabs.length === 0
-                  ? html`<div class="gc-dock-empty">Script completed without output.</div>`
-                  : nothing}
+          ${selectedExtensionTab
+            ? unsafeHTML(`<${selectedExtensionTab.element}></${selectedExtensionTab.element}>`)
+            : this.selectedTab === 'table' && table
+              ? this.renderTable(table)
+              : this.selectedTab === 'trace' && active
+                ? this.renderTrace(active.text)
+                : active
+                  ? html`<pre class="gc-dock-pre">${active.text}</pre>`
+                  : visibleTabs.length === 0
+                    ? html`<div class="gc-dock-empty">Script completed without output.</div>`
+                    : nothing}
         </div>
       </div>
     `;

--- a/ui.frontend/src/extensions/registry.ts
+++ b/ui.frontend/src/extensions/registry.ts
@@ -12,6 +12,7 @@ import { config } from '../config';
  * with the console exclusively through:
  *
  * - `window.GroovyConsole.registerPanel({ id, title, element, iconHtml })`
+ * - `window.GroovyConsole.getScript()` — the script currently in the editor (empty string if none)
  * - DOM events (bubbling, composed) handled by the console shell:
  *   - `gc-set-script`  detail: `{ script: string; message?: string }` — load a script into the editor
  *   - `gc-toast`       detail: `{ message: string; variant?: 'positive' | 'negative' }` — show a toast
@@ -32,6 +33,8 @@ export interface ConsolePanelExtension {
 
 export interface GroovyConsoleGlobal {
   registerPanel(panel: ConsolePanelExtension): void;
+  /** The script currently in the editor, or an empty string. */
+  getScript(): string;
 }
 
 declare global {
@@ -47,6 +50,13 @@ const CUSTOM_ELEMENT_NAME = /^[a-z][a-z0-9]*-[a-z0-9-]*$/;
 
 const panels: ConsolePanelExtension[] = [];
 const listeners = new Set<() => void>();
+
+/** Set by the console shell so extensions can read the editor's current script via `window.GroovyConsole.getScript()`. */
+let activeScriptProvider: (() => string) | null = null;
+
+export function setActiveScriptProvider(provider: () => string): void {
+  activeScriptProvider = provider;
+}
 
 export function getPanels(): readonly ConsolePanelExtension[] {
   return panels;
@@ -78,7 +88,7 @@ export function initConsoleExtensions(): void {
   }
   initialized = true;
 
-  window.GroovyConsole = { registerPanel };
+  window.GroovyConsole = { registerPanel, getScript: () => (activeScriptProvider ? activeScriptProvider() : '') };
 
   for (const url of config.uiExtensions) {
     import(/* @vite-ignore */ `${config.contextPath}${url}`).catch((error: unknown) => {

--- a/ui.frontend/src/extensions/registry.ts
+++ b/ui.frontend/src/extensions/registry.ts
@@ -1,17 +1,20 @@
 import { config } from '../config';
+import type { RunScriptResponse } from '../api/types';
 
 /**
  * Console UI extension mechanism.
  *
  * Backend bundles announce ES modules by registering a
  * `be.orbinson.aem.groovy.console.api.ConsoleUiExtensionProvider` OSGi service; the URLs arrive in the
- * page config (`uiExtensions`) and are dynamically imported here.  Each module registers panels for the
- * console's activity rail via the `window.GroovyConsole.registerPanel(...)` global.
+ * page config (`uiExtensions`) and are dynamically imported here.  Each module registers panels, run
+ * actions, and result tabs via the `window.GroovyConsole` global.
  *
  * Extension modules must be self-contained (define their own custom elements and styles) and interact
  * with the console exclusively through:
  *
- * - `window.GroovyConsole.registerPanel({ id, title, element, iconHtml })`
+ * - `window.GroovyConsole.registerPanel({ id, title, element, iconHtml })` — activity-rail drawer panel
+ * - `window.GroovyConsole.registerRunAction({ id, label, run })` — entry in the Run button's options menu
+ * - `window.GroovyConsole.registerRunResultTab({ id, label, element, isRelevant })` — tab in the output dock
  * - `window.GroovyConsole.getScript()` — the script currently in the editor (empty string if none)
  * - DOM events (bubbling, composed) handled by the console shell:
  *   - `gc-set-script`  detail: `{ script: string; message?: string }` — load a script into the editor
@@ -31,8 +34,36 @@ export interface ConsolePanelExtension {
   iconHtml?: string;
 }
 
+/** A run result as stored by the shell: a RunScriptResponse plus any extra fields a run action attached. */
+export type ExtendedRunResult = RunScriptResponse & Record<string, unknown>;
+
+export interface ConsoleRunActionExtension {
+  /** Unique action id. */
+  id: string;
+  /** Menu entry label, e.g. "Run with query audit". */
+  label: string;
+  /**
+   * Execute the current script. The returned object is stored as the run result and rendered by the
+   * output dock; extra fields beyond RunScriptResponse are kept and can drive a registered result tab.
+   */
+  run(context: { script: string; data: string }): Promise<ExtendedRunResult>;
+}
+
+export interface ConsoleRunResultTabExtension {
+  /** Unique tab id. */
+  id: string;
+  /** Tab label in the output dock. */
+  label: string;
+  /** Custom element tag rendered as the tab body; the dock assigns the run result to its `result` property. */
+  element: string;
+  /** Whether this tab applies to the given run result (e.g. the result carries the extension's extra field). */
+  isRelevant(result: ExtendedRunResult): boolean;
+}
+
 export interface GroovyConsoleGlobal {
   registerPanel(panel: ConsolePanelExtension): void;
+  registerRunAction(action: ConsoleRunActionExtension): void;
+  registerRunResultTab(tab: ConsoleRunResultTabExtension): void;
   /** The script currently in the editor, or an empty string. */
   getScript(): string;
 }
@@ -49,6 +80,8 @@ declare global {
 const CUSTOM_ELEMENT_NAME = /^[a-z][a-z0-9]*-[a-z0-9-]*$/;
 
 const panels: ConsolePanelExtension[] = [];
+const runActions: ConsoleRunActionExtension[] = [];
+const runResultTabs: ConsoleRunResultTabExtension[] = [];
 const listeners = new Set<() => void>();
 
 /** Set by the console shell so extensions can read the editor's current script via `window.GroovyConsole.getScript()`. */
@@ -62,9 +95,22 @@ export function getPanels(): readonly ConsolePanelExtension[] {
   return panels;
 }
 
-export function onPanelsChanged(listener: () => void): () => void {
+export function getRunActions(): readonly ConsoleRunActionExtension[] {
+  return runActions;
+}
+
+export function getRunResultTabs(): readonly ConsoleRunResultTabExtension[] {
+  return runResultTabs;
+}
+
+/** Notifies on any extension registration (panels, run actions, result tabs). */
+export function onExtensionsChanged(listener: () => void): () => void {
   listeners.add(listener);
   return () => listeners.delete(listener);
+}
+
+function notify(): void {
+  listeners.forEach((listener) => listener());
 }
 
 function registerPanel(panel: ConsolePanelExtension): void {
@@ -76,7 +122,29 @@ function registerPanel(panel: ConsolePanelExtension): void {
     return;
   }
   panels.push(panel);
-  listeners.forEach((listener) => listener());
+  notify();
+}
+
+function registerRunAction(action: ConsoleRunActionExtension): void {
+  if (!action?.id || !action.label || typeof action.run !== 'function'
+      || runActions.some((existing) => existing.id === action.id)) {
+    return;
+  }
+  runActions.push(action);
+  notify();
+}
+
+function registerRunResultTab(tab: ConsoleRunResultTabExtension): void {
+  if (!tab?.id || !tab.label || typeof tab.isRelevant !== 'function'
+      || runResultTabs.some((existing) => existing.id === tab.id)) {
+    return;
+  }
+  if (!CUSTOM_ELEMENT_NAME.test(tab.element)) {
+    console.error(`[groovyconsole] ignoring result tab "${tab.id}": invalid element name "${tab.element}"`);
+    return;
+  }
+  runResultTabs.push(tab);
+  notify();
 }
 
 let initialized = false;
@@ -88,7 +156,12 @@ export function initConsoleExtensions(): void {
   }
   initialized = true;
 
-  window.GroovyConsole = { registerPanel, getScript: () => (activeScriptProvider ? activeScriptProvider() : '') };
+  window.GroovyConsole = {
+    registerPanel,
+    registerRunAction,
+    registerRunResultTab,
+    getScript: () => (activeScriptProvider ? activeScriptProvider() : ''),
+  };
 
   for (const url of config.uiExtensions) {
     import(/* @vite-ignore */ `${config.contextPath}${url}`).catch((error: unknown) => {

--- a/ui.frontend/src/styles/app.css
+++ b/ui.frontend/src/styles/app.css
@@ -102,6 +102,25 @@ body {
   background: var(--spectrum-gray-200);
 }
 
+/* Split Run button: primary Run + attached options chevron (only rendered when extensions register run actions).
+   The group background shows through the 1px gap as the divider between the two segments. */
+.gc-run-group {
+  display: inline-flex;
+  gap: 1px;
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+/* direct child only: the chevron sits nested inside .gc-overflow and must not pick up the left rounding */
+.gc-run-group > sp-button {
+  --mod-button-border-radius: 16px 0 0 16px;
+}
+
+.gc-run-group .gc-run-more {
+  --mod-button-border-radius: 0 16px 16px 0;
+  min-width: 0;
+}
+
 .gc-classic-link {
   font-size: 13px;
   color: var(--spectrum-blue-900);

--- a/ui.tests/pom.xml
+++ b/ui.tests/pom.xml
@@ -231,5 +231,13 @@
             <type>zip</type>
             <scope>provided</scope>
         </dependency>
+        <!-- Query-audit extension bundle (no content package): installed via a feature file; the dependency
+             enforces reactor ordering so the bundle is built and available to the feature launcher. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>aem-groovy-console-query-audit</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/ui.tests/specs/query-audit.spec.ts
+++ b/ui.tests/specs/query-audit.spec.ts
@@ -1,15 +1,25 @@
 import { expect, test } from '@playwright/test';
-import { openDrawer, openModernUi, setScriptContent } from './helpers';
+import { expectToast, openModernUi, setScriptContent } from './helpers';
+
+/** Open the Run options menu (the chevron next to Run) and click the given action. */
+async function clickRunAction(page: Parameters<typeof openModernUi>[0], label: string): Promise<void> {
+  await page.locator('.gc-run-group .gc-run-more').click();
+  await page.locator('.gc-run-group .gc-overflow-menu button', { hasText: label }).click();
+}
 
 test.describe('query audit', () => {
-  test('registers a Query audit panel in the modern console', async ({ page }) => {
+  test('adds "Run with query audit" to the run options menu', async ({ page }) => {
     await openModernUi(page);
 
-    // the query-audit extension contributes a rail panel via ConsoleUiExtensionProvider
-    await expect(page.locator('.gc-rail-button[title="Query audit"]')).toBeVisible({ timeout: 30_000 });
+    // the query-audit extension registers a run action; the chevron only renders when actions exist
+    const chevron = page.locator('.gc-run-group .gc-run-more');
+    await expect(chevron).toBeVisible({ timeout: 30_000 });
+
+    await chevron.click();
+    await expect(page.locator('.gc-run-group .gc-overflow-menu')).toContainText('Run with query audit');
   });
 
-  test('audits the active editor script and flags an un-indexed query', async ({ page }) => {
+  test('runs the script and flags an un-indexed query in the Query audit tab', async ({ page }) => {
     await openModernUi(page);
 
     // a query on a custom (un-indexed) property -> Oak must traverse -> flagged as needing an index
@@ -18,22 +28,24 @@ test.describe('query audit', () => {
       "sql2Query(\"SELECT * FROM [nt:base] AS n WHERE ISDESCENDANTNODE(n, '/content') AND n.[qaMarker] = 'x'\")",
     );
 
-    await openDrawer(page, 'Query audit');
-    await page.getByRole('button', { name: 'Audit active script' }).click();
+    await clickRunAction(page, 'Run with query audit');
 
-    // the panel renders a row for the executed query, flagged "needs index", with the statement and Oak plan
-    await expect(page.locator('query-audit-panel .needs')).toContainText('needs index', { timeout: 20_000 });
-    await expect(page.locator('query-audit-panel')).toContainText('qaMarker');
-    await expect(page.locator('query-audit-panel')).toContainText('traverse');
+    // the audit result opens as a tab in the output dock, next to Log/Result
+    await expect(page.locator('.gc-dock-tab', { hasText: 'Query audit' })).toBeVisible({ timeout: 20_000 });
+    const result = page.locator('query-audit-result');
+    await expect(result.locator('.qa-needs')).toContainText('needs index');
+    await expect(result).toContainText('qaMarker');
+    await expect(result.locator('.qa-lang')).toContainText('JCR-SQL2');
+    await result.locator('.qa-plan summary').click();
+    await expect(result).toContainText('traverse');
   });
 
-  test('reports nothing to audit when the editor is empty', async ({ page }) => {
+  test('shows a toast when auditing an empty editor', async ({ page }) => {
     await openModernUi(page);
     await setScriptContent(page, '');
 
-    await openDrawer(page, 'Query audit');
-    await page.getByRole('button', { name: 'Audit active script' }).click();
+    await clickRunAction(page, 'Run with query audit');
 
-    await expect(page.locator('query-audit-panel')).toContainText('editor is empty');
+    await expectToast(page, 'Script is empty.');
   });
 });

--- a/ui.tests/specs/query-audit.spec.ts
+++ b/ui.tests/specs/query-audit.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { openDrawer, openModernUi, setScriptContent } from './helpers';
+
+test.describe('query audit', () => {
+  test('registers a Query audit panel in the modern console', async ({ page }) => {
+    await openModernUi(page);
+
+    // the query-audit extension contributes a rail panel via ConsoleUiExtensionProvider
+    await expect(page.locator('.gc-rail-button[title="Query audit"]')).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('audits the active editor script and flags an un-indexed query', async ({ page }) => {
+    await openModernUi(page);
+
+    // a query on a custom (un-indexed) property -> Oak must traverse -> flagged as needing an index
+    await setScriptContent(
+      page,
+      "sql2Query(\"SELECT * FROM [nt:base] AS n WHERE ISDESCENDANTNODE(n, '/content') AND n.[qaMarker] = 'x'\")",
+    );
+
+    await openDrawer(page, 'Query audit');
+    await page.getByRole('button', { name: 'Audit active script' }).click();
+
+    // the panel renders a row for the executed query, flagged "needs index", with the statement and Oak plan
+    await expect(page.locator('query-audit-panel .needs')).toContainText('needs index', { timeout: 20_000 });
+    await expect(page.locator('query-audit-panel')).toContainText('qaMarker');
+    await expect(page.locator('query-audit-panel')).toContainText('traverse');
+  });
+
+  test('reports nothing to audit when the editor is empty', async ({ page }) => {
+    await openModernUi(page);
+    await setScriptContent(page, '');
+
+    await openDrawer(page, 'Query audit');
+    await page.getByRole('button', { name: 'Audit active script' }).click();
+
+    await expect(page.locator('query-audit-panel')).toContainText('editor is empty');
+  });
+});

--- a/ui.tests/src/main/features/groovyconsole-query-audit.json
+++ b/ui.tests/src/main/features/groovyconsole-query-audit.json
@@ -1,0 +1,8 @@
+{
+  "bundles":[
+    {
+      "id": "be.orbinson.aem:aem-groovy-console-query-audit:20.0.0-SNAPSHOT",
+      "start-order": "20"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Detect whether the JCR queries a Groovy Console script runs are backed by an Oak index, so a project can verify the indexes its migration/report scripts rely on actually exist — before shipping.

### Query-audit extension (`extensions/query-audit`)
A single optional OSGi bundle (no content package, not in the core `all` package):
- **`POST /bin/groovyconsole/query-audit`** with a `script` or `scriptPath` — same permission model as script execution. Runs the script, captures the statements Oak executes, `EXPLAIN`s each against the live repository, and returns JSON:
  ```json
  { "output": "…", "exceptionStackTrace": "",
    "queries": [ { "statement": "…", "plan": "…", "needsIndex": true } ] }
  ```
  `needsIndex=true` means Oak had to traverse — no index on this instance covers that query.
- Mirrors AEM's **Explain Query** tool: a logback collector over the Oak query + Day QueryBuilder loggers, isolated per request via an MDC marker. Pure Java; logback is `provided`/optional so the **core console stays logback-free and Cloud-safe**.
- **Query audit panel** in the modern console (a `ConsoleUiExtensionProvider` + a servlet serving a self-contained ES module from the bundle): audits the script **currently in the editor** and shows the per-query index report — no pasting.

### Modern console extension API
Adds `window.GroovyConsole.getScript()` so a UI extension can read the editor's active script (the shell provides it via `setActiveScriptProvider`). Small, general addition alongside the existing `registerPanel` / `gc-set-script` / `gc-toast` contract.

### Optional migration integration
A migration run started with `measureIndexUsage=true` measures each script's index usage via the (optional) `QueryAuditService` and reports per-script findings — useful for validating migrations in **CI**. **No hard dependency**: the reference is optional/dynamic, so the migration extension works with or without the query-audit extension installed (e.g. on AEM as a Cloud Service, where it's simply skipped).

### Unit-test index audit (`ui.content`)
`IndexAudit` runs a script against real in-memory Oak (`JCR_OAK`) and reports the plan per query, so a **unit test** can list the indexes a script needs and verify coverage once a definition is installed (property indexes; Lucene needs a live instance).

### Live ITs (`it.tests`)
`IndexDetectionIT` and `MigrationIndexAuditIT` validate the servlet and the migration integration against the running instance's real Oak indexes.

## Notes
- No changes to the core console runtime beyond the small `getScript()` extension-API addition; the extension and the migration hook are entirely opt-in.
- Exploratory material (design docs, the raw-Oak spike, the sling-mock-oak Lucene contribution patch) is intentionally kept out of this PR.

## Testing
`mvn test -pl bundle,extensions/migration/bundle,ui.content` green (11 / 31 / 15); `ui.frontend` tsc + unit tests green. `mvn clean install -Pit -Dit.test=IndexDetectionIT,MigrationIndexAuditIT` green against a live Sling instance.