### PR TITLE
Store report scripts as .groovy file nodes

### DIFF
--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportService.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportService.groovy
@@ -39,8 +39,6 @@ class DefaultReportService implements ReportService {
 
     private static final String PROPERTY_CATEGORY = "category"
 
-    // the script is stored as a "<report name>.groovy" nt:file child so it ships as a real file in the content
-    // package and can be unit-tested with the console test-support harness, rather than an opaque string property
     private static final String SCRIPT_FILE_SUFFIX = ".groovy"
 
     private static final String SCRIPT_MIME_TYPE = "application/x-groovy"

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportService.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportService.groovy
@@ -17,6 +17,7 @@ import org.osgi.service.component.annotations.Component
 
 import javax.jcr.Session
 
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.CHARSET
 import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.PARAMETERS_NODE_NAME
 import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.PATH_REPORTS_FOLDER
 import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.RESOURCE_TYPE_DEFINITION
@@ -38,7 +39,11 @@ class DefaultReportService implements ReportService {
 
     private static final String PROPERTY_CATEGORY = "category"
 
-    private static final String PROPERTY_SCRIPT = "script"
+    // the script is stored as a "<report name>.groovy" nt:file child so it ships as a real file in the content
+    // package and can be unit-tested with the console test-support harness, rather than an opaque string property
+    private static final String SCRIPT_FILE_SUFFIX = ".groovy"
+
+    private static final String SCRIPT_MIME_TYPE = "application/x-groovy"
 
     private static final String PROPERTY_PAGE_SIZE = "pageSize"
 
@@ -93,11 +98,11 @@ class DefaultReportService implements ReportService {
             valueMap.put(PROPERTY_TITLE, reportDefinition.title ?: reportDefinition.name)
             putOrRemove(valueMap, PROPERTY_DESCRIPTION, reportDefinition.description)
             putOrRemove(valueMap, PROPERTY_CATEGORY, reportDefinition.category)
-            putOrRemove(valueMap, PROPERTY_SCRIPT, reportDefinition.script)
             putOrRemove(valueMap, PROPERTY_PAGE_SIZE, reportDefinition.pageSize)
             valueMap.put(PROPERTY_LAST_MODIFIED, Calendar.instance)
             valueMap.put(PROPERTY_LAST_MODIFIED_BY, userId)
 
+            saveScript(resourceResolver, resource, reportDefinition.script)
             saveParameters(resourceResolver, resource, reportDefinition.parameters)
 
             resourceResolver.commit()
@@ -202,6 +207,24 @@ class DefaultReportService implements ReportService {
         }
     }
 
+    private static void saveScript(ResourceResolver resourceResolver, Resource reportResource, String script) {
+        // replace any existing script file (defensive; the file name tracks the report node name)
+        reportResource.listChildren().findAll { child -> isScriptFile(child) }.each { child ->
+            resourceResolver.delete(child)
+        }
+
+        def fileResource = resourceResolver.create(reportResource, "${reportResource.name}$SCRIPT_FILE_SUFFIX",
+                [(JcrConstants.JCR_PRIMARYTYPE): JcrConstants.NT_FILE] as Map<String, Object>)
+
+        resourceResolver.create(fileResource, JcrConstants.JCR_CONTENT, [
+                (JcrConstants.JCR_PRIMARYTYPE) : JcrConstants.NT_RESOURCE,
+                (JcrConstants.JCR_MIMETYPE)    : SCRIPT_MIME_TYPE,
+                (JcrConstants.JCR_ENCODING)    : CHARSET,
+                (JcrConstants.JCR_LASTMODIFIED): Calendar.instance,
+                (JcrConstants.JCR_DATA)        : new ByteArrayInputStream(script.getBytes(CHARSET))
+        ] as Map<String, Object>)
+    }
+
     private static void saveParameters(ResourceResolver resourceResolver, Resource reportResource,
                                        List<ReportParameter> parameters) {
         def parametersResource = reportResource.getChild(PARAMETERS_NODE_NAME)
@@ -246,8 +269,21 @@ class DefaultReportService implements ReportService {
     }
 
     private static boolean isReportDefinition(Resource resource) {
-        resource.name != "rep:policy" && (resource.isResourceType(RESOURCE_TYPE_DEFINITION)
-                || resource.valueMap.containsKey(PROPERTY_SCRIPT))
+        resource.isResourceType(RESOURCE_TYPE_DEFINITION)
+    }
+
+    private static boolean isScriptFile(Resource resource) {
+        resource.name.endsWith(SCRIPT_FILE_SUFFIX)
+    }
+
+    private static String readScript(Resource reportResource) {
+        def scriptFile = reportResource.listChildren().find { child -> isScriptFile(child) }
+
+        def stream = scriptFile?.getChild(JcrConstants.JCR_CONTENT)
+                ?.valueMap
+                ?.get(JcrConstants.JCR_DATA, InputStream)
+
+        stream?.withCloseable { it.getText(CHARSET) }
     }
 
     private static Resource getReportResource(ResourceResolver resourceResolver, String name) {
@@ -268,7 +304,7 @@ class DefaultReportService implements ReportService {
                 title: properties.get(PROPERTY_TITLE, resource.name),
                 description: properties.get(PROPERTY_DESCRIPTION, String),
                 category: properties.get(PROPERTY_CATEGORY, String),
-                script: properties.get(PROPERTY_SCRIPT, String),
+                script: readScript(resource),
                 pageSize: properties.get(PROPERTY_PAGE_SIZE, Integer),
                 parameters: toParameters(resource),
                 created: properties.get(JcrConstants.JCR_CREATED, Calendar),

--- a/extensions/reports/ui.content/pom.xml
+++ b/extensions/reports/ui.content/pom.xml
@@ -50,6 +50,20 @@
             <artifactId>aem-groovy-console-reports-bundle</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- report DSL classes (ReportColumnType, ReportDsl, ReportScriptContext) the sample script and tests use -->
+        <dependency>
+            <groupId>be.orbinson.aem</groupId>
+            <artifactId>aem-groovy-console-reports-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Unit-test the shipped report scripts -->
+        <dependency>
+            <groupId>be.orbinson.aem</groupId>
+            <artifactId>aem-groovy-console-test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/extensions/reports/ui.content/pom.xml
+++ b/extensions/reports/ui.content/pom.xml
@@ -50,14 +50,12 @@
             <artifactId>aem-groovy-console-reports-bundle</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- report DSL classes (ReportColumnType, ReportDsl, ReportScriptContext) the sample script and tests use -->
         <dependency>
             <groupId>be.orbinson.aem</groupId>
             <artifactId>aem-groovy-console-reports-api</artifactId>
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Unit-test the shipped report scripts -->
         <dependency>
             <groupId>be.orbinson.aem</groupId>
             <artifactId>aem-groovy-console-test-support</artifactId>

--- a/extensions/reports/ui.content/src/main/content/jcr_root/conf/groovyconsole/reports/sample-content-listing/.content.xml
+++ b/extensions/reports/ui.content/src/main/content/jcr_root/conf/groovyconsole/reports/sample-content-listing/.content.xml
@@ -5,8 +5,7 @@
           jcr:title="Sample: Content listing"
           description="Lists the child resources of a content path with name, link and resource type. Works on both AEM and plain Sling."
           category="Samples"
-          pageSize="{Long}25"
-          script="import be.orbinson.aem.groovy.console.reports.data.ReportColumnType&#xa;&#xa;def data = report.data()&#xa;&#xa;data.column(&apos;Name&apos;)&#xa;data.column(&apos;Path&apos;, ReportColumnType.LINK)&#xa;data.column(&apos;Type&apos;)&#xa;// UI-only column: shown in the table but omitted from the CSV/XLSX export (exported = false)&#xa;data.column(&apos;Edit&apos;, ReportColumnType.LINK, false)&#xa;&#xa;def resource = resourceResolver.getResource(params.path)&#xa;&#xa;resource?.listChildren()?.each { child -&gt;&#xa;    data.row(&#xa;        child.name,&#xa;        [text: child.name, href: child.path],&#xa;        child.resourceType,&#xa;        [text: &apos;Edit&apos;, href: &quot;/editor.html${child.path}.html&quot;]&#xa;    )&#xa;}&#xa;&#xa;data">
+          pageSize="{Long}25">
     <parameters jcr:primaryType="nt:unstructured">
         <path
             jcr:primaryType="nt:unstructured"

--- a/extensions/reports/ui.content/src/main/content/jcr_root/conf/groovyconsole/reports/sample-content-listing/sample-content-listing.groovy
+++ b/extensions/reports/ui.content/src/main/content/jcr_root/conf/groovyconsole/reports/sample-content-listing/sample-content-listing.groovy
@@ -1,0 +1,22 @@
+import be.orbinson.aem.groovy.console.reports.data.ReportColumnType
+
+def data = report.data()
+
+data.column('Name')
+data.column('Path', ReportColumnType.LINK)
+data.column('Type')
+// UI-only column: shown in the table but omitted from the CSV/XLSX export (exported = false)
+data.column('Edit', ReportColumnType.LINK, false)
+
+def resource = resourceResolver.getResource(params.path)
+
+resource?.listChildren()?.each { child ->
+    data.row(
+        child.name,
+        [text: child.name, href: child.path],
+        child.resourceType,
+        [text: 'Edit', href: "/editor.html${child.path}.html"]
+    )
+}
+
+data

--- a/extensions/reports/ui.content/src/test/java/be/orbinson/aem/groovy/console/reports/samples/ReportConsole.java
+++ b/extensions/reports/ui.content/src/test/java/be/orbinson/aem/groovy/console/reports/samples/ReportConsole.java
@@ -1,0 +1,56 @@
+package be.orbinson.aem.groovy.console.reports.samples;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.sling.testing.mock.sling.context.SlingContextImpl;
+
+import be.orbinson.aem.groovy.console.GroovyConsoleService;
+import be.orbinson.aem.groovy.console.reports.impl.DefaultReportScriptContext;
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+
+/**
+ * Runs a report script the way the reports extension does at runtime: through a {@link DefaultReportScriptContext}
+ * so the {@code report} and {@code params} bindings are injected by the {@code ReportBindingExtensionProvider}.
+ * <p>
+ * The context must have a {@link GroovyConsoleService} registered (via {@code ContextPlugins.GROOVY_CONSOLE}) and
+ * the {@code ReportBindingExtensionProvider} registered so those report bindings resolve.
+ */
+final class ReportConsole {
+
+    private ReportConsole() {
+    }
+
+    static RunScriptResponse runReport(SlingContextImpl context, String script, Map<String, Object> parameters) {
+        GroovyConsoleService service = context.getService(GroovyConsoleService.class);
+
+        if (service == null) {
+            throw new IllegalStateException("GroovyConsoleService is not registered. Add ContextPlugins.GROOVY_CONSOLE "
+                    + "to your context builder.");
+        }
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        DefaultReportScriptContext scriptContext = new DefaultReportScriptContext();
+        scriptContext.setReportName("test-report");
+        scriptContext.setParameterValues(parameters);
+        scriptContext.setResourceResolver(context.resourceResolver());
+        scriptContext.setOutputStream(outputStream);
+        scriptContext.setPrintStream(printStream(outputStream));
+        scriptContext.setScript(script);
+        scriptContext.setUserId(context.resourceResolver().getUserID());
+
+        return service.runScript(scriptContext);
+    }
+
+    private static PrintStream printStream(ByteArrayOutputStream outputStream) {
+        try {
+            return new PrintStream(outputStream, true, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/extensions/reports/ui.content/src/test/java/be/orbinson/aem/groovy/console/reports/samples/Reports.java
+++ b/extensions/reports/ui.content/src/test/java/be/orbinson/aem/groovy/console/reports/samples/Reports.java
@@ -1,0 +1,27 @@
+package be.orbinson.aem.groovy.console.reports.samples;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Reads a shipped report's {@code .groovy} script from this module's content so tests exercise the exact script
+ * that is deployed. Reports store their script as a {@code <report name>/<report name>.groovy} file node.
+ */
+final class Reports {
+
+    private static final Path DIR = Path.of("src/main/content/jcr_root/conf/groovyconsole/reports");
+
+    private Reports() {
+    }
+
+    static String readScript(String reportName) {
+        try {
+            return Files.readString(DIR.resolve(reportName).resolve(reportName + ".groovy"), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/extensions/reports/ui.content/src/test/java/be/orbinson/aem/groovy/console/reports/samples/SampleContentListingTest.java
+++ b/extensions/reports/ui.content/src/test/java/be/orbinson/aem/groovy/console/reports/samples/SampleContentListingTest.java
@@ -1,0 +1,50 @@
+package be.orbinson.aem.groovy.console.reports.samples;
+
+import be.orbinson.aem.groovy.console.reports.extension.ReportBindingExtensionProvider;
+import be.orbinson.aem.groovy.console.response.RunScriptResponse;
+import be.orbinson.aem.groovy.console.testing.ContextPlugins;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextBuilder;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the shipped {@code sample-content-listing} report script: it lists the child resources of a content path.
+ * <p>
+ * Because reports now store their script as a real {@code .groovy} file node, the test loads the exact deployed
+ * script and runs it through the console with the report bindings ({@code report}, {@code params}).
+ */
+@ExtendWith(SlingContextExtension.class)
+class SampleContentListingTest {
+
+    // register the reports' binding provider before the console starts so `report` and `params` resolve
+    private final SlingContext context = new SlingContextBuilder()
+            .beforeSetUp(ctx -> ctx.registerInjectActivateService(new ReportBindingExtensionProvider()))
+            .plugin(ContextPlugins.GROOVY_CONSOLE)
+            .build();
+
+    @Test
+    void listsChildResources() {
+        context.create().resource("/content/site");
+        context.create().resource("/content/site/en", "sling:resourceType", "app/components/page");
+        context.create().resource("/content/site/fr", "sling:resourceType", "app/components/page");
+
+        RunScriptResponse response = ReportConsole.runReport(context,
+                Reports.readScript("sample-content-listing"), Map.of("path", "/content/site"));
+
+        assertTrue(response.getExceptionStackTrace().isEmpty(), response.getExceptionStackTrace());
+
+        // the script returns ReportData, which the console serializes as a { "reportData": { columns, rows } } envelope
+        String result = response.getResult();
+        assertTrue(result.contains("reportData"), "expected a reportData envelope but was: [" + result + "]");
+        assertTrue(result.contains("/content/site/en") && result.contains("/content/site/fr"),
+                "expected both child paths in the result but was: [" + result + "]");
+        assertTrue(result.contains("app/components/page"),
+                "expected the child resource type in the result but was: [" + result + "]");
+    }
+}

--- a/extensions/reports/ui.content/src/test/java/be/orbinson/aem/groovy/console/reports/samples/SampleContentListingTest.java
+++ b/extensions/reports/ui.content/src/test/java/be/orbinson/aem/groovy/console/reports/samples/SampleContentListingTest.java
@@ -15,9 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests the shipped {@code sample-content-listing} report script: it lists the child resources of a content path.
- * <p>
- * Because reports now store their script as a real {@code .groovy} file node, the test loads the exact deployed
- * script and runs it through the console with the report bindings ({@code report}, {@code params}).
  */
 @ExtendWith(SlingContextExtension.class)
 class SampleContentListingTest {


### PR DESCRIPTION
## What

Report definition scripts were persisted as an opaque `script` string property on the report node. In the content package that meant the shipped script lived inside an XML attribute (`script="...&#xa;..."`), which cannot be loaded cleanly by a unit test.

This stores the script instead as a **`<report name>.groovy` `nt:file` child** of the report node, so it ships as a real Groovy file in the content package and can be executed through the console test-support harness.

## Changes

- **`DefaultReportService`** — `saveScript`/`readScript` write and read the script via a `<report name>.groovy` nt:file child (`jcr:content`/`jcr:data`, mime `application/x-groovy`). `isReportDefinition` now keys purely on `sling:resourceType=groovyconsole/reports/definition` (the legacy `containsKey('script')` branch is gone). **Clean break** — no fallback to the old property.
- **Sample** — `sample-content-listing` now ships its script as a sibling `sample-content-listing.groovy` file instead of a `script` attribute in `.content.xml`.
- **Unit test** — `extensions/reports/ui.content/src/test/.../reports/samples/`: a `Reports` loader (reads the exact deployed `.groovy`), a `ReportConsole` runner (builds a `DefaultReportScriptContext` and registers `ReportBindingExtensionProvider` in `beforeSetUp` so `report`/`params` bind), and `SampleContentListingTest` which runs the shipped sample and asserts on the returned report data. Adds `reports-api` + `test-support` test deps to the module POM.

The servlet API still carries the script as a JSON string, so the **frontend is unchanged** — only persistence changed.

## Testing

- `mvn clean install` — BUILD SUCCESS (full reactor).
- New `SampleContentListingTest` passes; existing reports bundle tests still green.