### PR TITLE
AuditRecord: use explicit non-final getters for path/response

### DIFF
--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/audit/AuditRecord.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/audit/AuditRecord.groovy
@@ -11,14 +11,22 @@ class AuditRecord implements RunScriptResponse {
 
     private static final Integer DEPTH_RELATIVE_PATH = 3
 
-    final String path
+    private final String path
 
     @Delegate
-    final RunScriptResponse response
+    private final RunScriptResponse response
 
     AuditRecord(Resource resource) {
         path = resource.path
         response = DefaultRunScriptResponse.fromAuditRecordResource(resource)
+    }
+
+    String getPath() {
+        path
+    }
+
+    RunScriptResponse getResponse() {
+        response
     }
 
     String getDownloadUrl() {


### PR DESCRIPTION
## Summary

Same underlying issue as fixed on `19.x` (#86): a `final` field makes Groovy generate a `final` accessor, and this project's `groovy-eclipse-compiler`/`groovy-eclipse-batch` toolchain has been observed to flip that non-deterministically across otherwise identical rebuilds (verified by rebuilding the unmodified `19.1.0` tag from scratch in isolation — same source, same flip). `bnd-baseline` treats an added `final` as a MAJOR break.

Currently masked here by the blanket `20.0.0` bump already applied to all `api` packages, but worth fixing at the source so a future minor release on this line isn't forced into an unnecessary major bump for the same reason.

`path`/`response` are now `private final` fields with explicit, hand-written non-final getters, bypassing Groovy's implicit property-accessor generation entirely. No behavior change — verified nothing outside `@Delegate`/reflection-based JSON serialization depends on these accessors directly.

## Verification

- `mvn test -pl api,bundle -am` — 11/11 tests pass, including `DefaultAuditServiceTest`.