### PR TITLE
Modern UI polish pass, AEM shell integration and folder-aware script saving

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -57,6 +57,10 @@
             <groupId>com.adobe.aem</groupId>
             <artifactId>uber-jar</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/AbstractConsoleUiPageServlet.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/AbstractConsoleUiPageServlet.groovy
@@ -1,0 +1,72 @@
+package be.orbinson.aem.groovy.console.api
+
+import groovy.json.JsonBuilder
+import org.apache.sling.api.SlingHttpServletRequest
+import org.apache.sling.api.SlingHttpServletResponse
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet
+import org.osgi.framework.BundleContext
+
+import javax.servlet.ServletException
+
+/**
+ * Base for extension page servlets that serve a standalone console-styled SPA shell (reports,
+ * migrations): renders the HTML host document with the injected <code>window.__GC_CONFIG__</code>
+ * and detects AEM by service name so extension bundles need no (optional) AEM API imports.
+ *
+ * Subclasses declare the servlet component and forward their <code>@Activate</code> method to
+ * {@link #activate(BundleContext)}.
+ */
+abstract class AbstractConsoleUiPageServlet extends SlingSafeMethodsServlet {
+
+    private volatile BundleContext bundleContext
+
+    // public: Groovy dispatches the subclass's super.activate(...) call through the metaclass,
+    // which does not see protected methods of a superclass from another bundle
+    void activate(BundleContext bundleContext) {
+        this.bundleContext = bundleContext
+    }
+
+    /** Page title of the HTML document. */
+    protected abstract String getPageTitle()
+
+    /** JCR path the SPA assets are served from, without trailing slash. */
+    protected abstract String getAssetsPath()
+
+    /** Root custom element of the SPA (e.g. <code>gcr-app</code>). */
+    protected abstract String getAppElement()
+
+    /** Base name of the SPA's stylesheet/script assets (e.g. <code>reports</code> for reports.css/reports.js). */
+    protected abstract String getAssetName()
+
+    /** Detect AEM by service name so the bundle needs no (optional) import of AEM API packages. */
+    protected boolean isAem() {
+        bundleContext?.getServiceReference("com.day.cq.wcm.api.PageManagerFactory") != null
+    }
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        def contextPath = request.contextPath ?: ""
+        def configJson = new JsonBuilder([contextPath: contextPath, aem: isAem()]).toString()
+
+        response.contentType = "text/html"
+        response.characterEncoding = "UTF-8"
+
+        response.writer.write("""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>${pageTitle}</title>
+    <link rel="stylesheet" href="${contextPath}${assetsPath}/${assetName}.css"/>
+</head>
+<body>
+<${appElement}></${appElement}>
+<script>window.__GC_CONFIG__ = ${configJson};</script>
+<script type="module" src="${contextPath}${assetsPath}/${assetName}.js"></script>
+</body>
+</html>
+""")
+    }
+}

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("20.0.0")
+@org.osgi.annotation.versioning.Version("20.1.0")
 package be.orbinson.aem.groovy.console.api;

--- a/bundle/src/main/groovy/be/orbinson/aem/groovy/console/impl/DefaultGroovyConsoleService.groovy
+++ b/bundle/src/main/groovy/be/orbinson/aem/groovy/console/impl/DefaultGroovyConsoleService.groovy
@@ -108,9 +108,18 @@ class DefaultGroovyConsoleService implements GroovyConsoleService {
     SaveScriptResponse saveScript(ScriptData scriptData) {
         def resourceResolver = scriptData.resourceResolver
 
-        def folderResource = ResourceUtil.getOrCreateResource(resourceResolver, PATH_SCRIPTS_FOLDER, JcrResourceConstants.NT_SLING_FOLDER, JcrResourceConstants.NT_SLING_FOLDER, true);
+        // the file name may contain relative folder segments ("migration/test.groovy"); the file is
+        // saved into that folder below the scripts root, creating intermediate folders as needed
+        def segments = scriptData.fileName.tokenize('/')
 
-        def fileName = scriptData.fileName
+        if (!segments || segments.any { it == '.' || it == '..' }) {
+            throw new IllegalArgumentException("invalid script file name: ${scriptData.fileName}")
+        }
+
+        def fileName = segments[-1]
+        def folderPath = ([PATH_SCRIPTS_FOLDER] + segments[0..<segments.size() - 1]).join('/')
+
+        def folderResource = ResourceUtil.getOrCreateResource(resourceResolver, folderPath, JcrResourceConstants.NT_SLING_FOLDER, JcrResourceConstants.NT_SLING_FOLDER, true);
 
         if (folderResource.getChild(fileName)) {
             resourceResolver.delete(folderResource.getChild(fileName))
@@ -119,7 +128,7 @@ class DefaultGroovyConsoleService implements GroovyConsoleService {
 
         saveFile(resourceResolver, folderResource, scriptData.script, fileName, new Date(), "application/octet-stream")
 
-        new DefaultSaveScriptResponse(fileName)
+        new DefaultSaveScriptResponse(segments.join('/'))
     }
 
     @Override

--- a/bundle/src/test/groovy/be/orbinson/aem/groovy/console/impl/DefaultGroovyConsoleServiceTest.groovy
+++ b/bundle/src/test/groovy/be/orbinson/aem/groovy/console/impl/DefaultGroovyConsoleServiceTest.groovy
@@ -96,6 +96,31 @@ class DefaultGroovyConsoleServiceTest {
         assertEquals("println \"BEER\"", script);
     }
 
+    @Test
+    void saveScriptIntoSubfolder() {
+        def consoleService = context.getService(GroovyConsoleService)
+
+        def request = context.request();
+        request.setParameterMap([(GroovyConsoleConstants.FILE_NAME): "migration/sub/$SCRIPT_NAME".toString(), (SCRIPT): scriptAsString])
+
+        def response = consoleService.saveScript(new RequestScriptData(request))
+
+        assertEquals("migration/sub/$SCRIPT_FILE_NAME".toString(), response.scriptName)
+        assertResourceExists("$PATH_SCRIPTS_FOLDER/migration", JcrResourceConstants.NT_SLING_FOLDER)
+        assertResourceExists("$PATH_SCRIPTS_FOLDER/migration/sub", JcrResourceConstants.NT_SLING_FOLDER)
+        assertResourceExists("$PATH_SCRIPTS_FOLDER/migration/sub/$SCRIPT_FILE_NAME", JcrConstants.NT_FILE)
+    }
+
+    @Test
+    void saveScriptRejectsPathTraversal() {
+        def consoleService = context.getService(GroovyConsoleService)
+
+        def request = context.request();
+        request.setParameterMap([(GroovyConsoleConstants.FILE_NAME): "../outside/$SCRIPT_NAME".toString(), (SCRIPT): scriptAsString])
+
+        assertThrows(IllegalArgumentException) { consoleService.saveScript(new RequestScriptData(request)) }
+    }
+
     void assertScriptResult(map) {
         assertNull(map.result)
         assertEquals("BEER" + System.lineSeparator(), map.output)

--- a/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/servlets/MigrationPageServlet.groovy
+++ b/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/servlets/MigrationPageServlet.groovy
@@ -1,16 +1,9 @@
 package be.orbinson.aem.groovy.console.migration.servlets
 
-import groovy.json.JsonBuilder
-import groovy.util.logging.Slf4j
-import org.apache.sling.api.SlingHttpServletRequest
-import org.apache.sling.api.SlingHttpServletResponse
-import org.apache.sling.api.servlets.SlingSafeMethodsServlet
+import be.orbinson.aem.groovy.console.api.AbstractConsoleUiPageServlet
 import org.osgi.service.component.annotations.Component
 
 import javax.servlet.Servlet
-import javax.servlet.ServletException
-
-import static be.orbinson.aem.groovy.console.constants.GroovyConsoleConstants.CHARSET
 
 /**
  * Serves the migration history UI shell at <code>/apps/groovyconsole/migrations.html</code>.
@@ -21,35 +14,25 @@ import static be.orbinson.aem.groovy.console.constants.GroovyConsoleConstants.CH
 @Component(service = Servlet, immediate = true, property = [
         "sling.servlet.paths=/apps/groovyconsole/migrations"
 ])
-@Slf4j("LOG")
-class MigrationPageServlet extends SlingSafeMethodsServlet {
-
-    private static final String ASSETS_PATH = "/apps/groovyconsole-migration/spa/assets"
+class MigrationPageServlet extends AbstractConsoleUiPageServlet {
 
     @Override
-    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
-            throws ServletException, IOException {
-        def contextPath = request.contextPath ?: ""
-        def configJson = new JsonBuilder([contextPath: contextPath]).toString()
+    protected String getPageTitle() {
+        "Migrations"
+    }
 
-        response.contentType = "text/html"
-        response.characterEncoding = CHARSET
+    @Override
+    protected String getAssetsPath() {
+        "/apps/groovyconsole-migration/spa/assets"
+    }
 
-        response.writer.write("""\
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Migrations</title>
-    <link rel="stylesheet" href="${contextPath}${ASSETS_PATH}/migration.css"/>
-</head>
-<body>
-<gcm-app></gcm-app>
-<script>window.__GC_CONFIG__ = ${configJson};</script>
-<script type="module" src="${contextPath}${ASSETS_PATH}/migration.js"></script>
-</body>
-</html>
-""")
+    @Override
+    protected String getAppElement() {
+        "gcm-app"
+    }
+
+    @Override
+    protected String getAssetName() {
+        "migration"
     }
 }

--- a/extensions/migration/ui.apps/pom.xml
+++ b/extensions/migration/ui.apps/pom.xml
@@ -31,9 +31,14 @@
                     <validatorsSettings>
                         <jackrabbit-filter>
                             <options>
-                                <validRoots>/apps,/apps/cq/core/content/nav/tools</validRoots>
+                                <validRoots>/apps,/apps/cq/core/content</validRoots>
                             </options>
                         </jackrabbit-filter>
+                        <jackrabbit-packagetype>
+                            <options>
+                                <allowComplexFilterRulesInApplicationPackages>true</allowComplexFilterRulesInApplicationPackages>
+                            </options>
+                        </jackrabbit-packagetype>
                     </validatorsSettings>
                 </configuration>
             </plugin>

--- a/extensions/migration/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/extensions/migration/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
-    <!-- AEM Tools console entry so operators can reach the migration history UI (overlay; AEM-only) -->
-    <filter root="/apps/cq/core/content/nav/tools/groovyconsole" mode="merge"/>
+    <!-- AEM Tools > Deployment entry so operators can reach the migration history UI (overlay; AEM-only).
+         Fine-grained includes so other entries under the shared nav nodes are left untouched. -->
+    <filter root="/apps/cq/core/content/nav">
+        <include pattern="/apps/cq/core/content/nav"/>
+        <include pattern="/apps/cq/core/content/nav/tools"/>
+        <include pattern="/apps/cq/core/content/nav/tools/deployment"/>
+        <include pattern="/apps/cq/core/content/nav/tools/deployment/groovyconsole-migrations(.*)?"/>
+    </filter>
     <!-- the migration SPA assets (built by extensions/migration/ui.frontend), on a migration-owned path -->
     <filter root="/apps/groovyconsole-migration"/>
 </workspaceFilter>

--- a/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/.content.xml
+++ b/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/.content.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-          jcr:primaryType="nt:unstructured"
-          jcr:title="Groovy Console"
-          id="cq-tools-groovyconsole"/>
+    jcr:primaryType="sling:OrderedFolder"/>

--- a/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/core/content/.content.xml
+++ b/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/core/content/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OrderedFolder"/>

--- a/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/.content.xml
+++ b/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OrderedFolder"/>

--- a/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/.content.xml
+++ b/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OrderedFolder"/>

--- a/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/deployment/.content.xml
+++ b/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/deployment/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OrderedFolder"/>

--- a/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/deployment/groovyconsole-migrations/.content.xml
+++ b/extensions/migration/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/deployment/groovyconsole-migrations/.content.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="nt:unstructured"
           jcr:title="Migrations"
-          jcr:description="Deployment migration run history and script registry"
-          id="cq-tools-groovyconsole-migrations"
+          jcr:description="Groovy Console migration run history and script registry"
+          id="granite-deployment-groovyconsole-migrations"
           href="/apps/groovyconsole/migrations.html"
           icon="gears"/>

--- a/extensions/migration/ui.frontend/package-lock.json
+++ b/extensions/migration/ui.frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "aem-groovy-console-migration-ui-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/source-code-pro": "^5.2.7",
+        "@fontsource/source-sans-3": "^5.2.9",
         "@spectrum-web-components/action-button": "^1.7.0",
         "@spectrum-web-components/badge": "^1.12.1",
         "@spectrum-web-components/button": "^1.7.0",
@@ -412,6 +414,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@fontsource/source-code-pro": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-code-pro/-/source-code-pro-5.2.7.tgz",
+      "integrity": "sha512-7papq9TH94KT+S5VSY8cU7tFmwuGkIe3qxXRMscuAXH6AjMU+KJI75f28FzgBVDrlMfA0jjlTV4/x5+H5o/5EQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/source-sans-3": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-3/-/source-sans-3-5.2.9.tgz",
+      "integrity": "sha512-u3ymIq4rfmCCyB9MEw/sFR5lPVJ1yTNXmIMbUz+9kVCFIHvNtfzXOEBuvkg3Tk0zhmioPeJ28ZK5smZ7TurezQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@lit-labs/observers": {

--- a/extensions/migration/ui.frontend/package.json
+++ b/extensions/migration/ui.frontend/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/source-code-pro": "^5.2.7",
+    "@fontsource/source-sans-3": "^5.2.9",
     "@spectrum-web-components/action-button": "^1.7.0",
     "@spectrum-web-components/badge": "^1.12.1",
     "@spectrum-web-components/button": "^1.7.0",

--- a/extensions/migration/ui.frontend/src/components/migration/gcm-app.ts
+++ b/extensions/migration/ui.frontend/src/components/migration/gcm-app.ts
@@ -1,6 +1,8 @@
 import { html, LitElement, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { config } from '@console/config';
 import { persistence } from '@console/state/local-storage';
+import '@console/components/gc-aem-nav';
 
 type View = { view: 'list' } | { view: 'run'; runId: string };
 
@@ -51,8 +53,13 @@ export class GcmApp extends LitElement {
     return html`
       <sp-theme class="gcm-root-theme" system="spectrum" color=${this.colorScheme} scale="medium">
         <div class="gcm-frame">
+          ${config.aem ? html`<gc-aem-nav></gc-aem-nav>` : nothing}
           <header class="gcm-app-bar">
-            <a class="gcm-brand" href="#/">Migrations</a>
+            <a class="gcm-brand" href="#/">
+              <span class="gcm-brand-context">Groovy Console</span>
+              <span class="gcm-brand-sep">/</span>
+              Migrations
+            </a>
             <div class="gcm-app-bar-actions">
               <sp-switch
                 ?checked=${this.colorScheme === 'dark'}

--- a/extensions/migration/ui.frontend/src/components/migration/gcm-run-detail.ts
+++ b/extensions/migration/ui.frontend/src/components/migration/gcm-run-detail.ts
@@ -58,11 +58,13 @@ export class GcmRunDetail extends LitElement {
 
     return html`
       <div class="gcm-page">
-        <div class="gcm-breadcrumbs"><a href="#/">Run history</a> / ${run.runId}</div>
+        <div class="gcm-breadcrumbs">
+          <a href="#/">Run history</a> / <span title=${run.runId}>${run.runId.slice(0, 8)}</span>
+        </div>
 
         <div class="gcm-page-header">
           <h2>Migration run</h2>
-          <sp-badge size="m" variant=${statusVariant(run.status)}>${run.status}</sp-badge>
+          <sp-badge size="s" variant=${statusVariant(run.status)}>${run.status}</sp-badge>
         </div>
 
         <dl class="gcm-meta">

--- a/extensions/migration/ui.frontend/src/components/migration/gcm-run-list.ts
+++ b/extensions/migration/ui.frontend/src/components/migration/gcm-run-list.ts
@@ -96,7 +96,9 @@ export class GcmRunList extends LitElement {
         <div class="gcm-page-header">
           <h2>Run history</h2>
           <div class="gcm-page-actions">
-            <sp-action-button size="s" quiet @click=${() => void this.refresh()} title="Refresh">↻</sp-action-button>
+            <sp-action-button size="s" quiet @click=${() => void this.refresh()} title="Refresh" aria-label="Refresh">
+              <sp-icon-refresh slot="icon"></sp-icon-refresh>
+            </sp-action-button>
             <sp-button
               size="s"
               variant="primary"

--- a/extensions/migration/ui.frontend/src/extensions/migration/gc-migration.ts
+++ b/extensions/migration/ui.frontend/src/extensions/migration/gc-migration.ts
@@ -184,7 +184,9 @@ export class GcMigration extends LitElement {
           ${this.triggering || this.running ? 'Running…' : 'Run migrations'}
         </sp-button>
         <span class="spacer"></span>
-        <sp-action-button size="s" quiet @click=${() => void this.refresh()} title="Refresh">↻</sp-action-button>
+        <sp-action-button size="s" quiet @click=${() => void this.refresh()} title="Refresh" aria-label="Refresh">
+          <sp-icon-refresh slot="icon"></sp-icon-refresh>
+        </sp-action-button>
         <sp-button size="s" variant="secondary" href=${migrationsPageUrl()} target="_blank">
           History
         </sp-button>

--- a/extensions/migration/ui.frontend/src/migration-main.ts
+++ b/extensions/migration/ui.frontend/src/migration-main.ts
@@ -1,4 +1,11 @@
 // Migration history UI entry point.
+// Bundled open fonts matching the Spectrum look (see @console tokens.css font stacks)
+import '@fontsource/source-sans-3/400.css';
+import '@fontsource/source-sans-3/600.css';
+import '@fontsource/source-sans-3/700.css';
+import '@fontsource/source-code-pro/400.css';
+import '@fontsource/source-code-pro/600.css';
+
 // Spectrum Web Components — per-component imports only (bundle size)
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/theme-light.js';
@@ -10,6 +17,7 @@ import '@spectrum-web-components/progress-circle/sp-progress-circle.js';
 import '@spectrum-web-components/switch/sp-switch.js';
 import '@spectrum-web-components/toast/sp-toast.js';
 import '@spectrum-web-components/badge/sp-badge.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-refresh.js';
 
 // App styles
 import './styles/migration.css';

--- a/extensions/migration/ui.frontend/src/styles/migration.css
+++ b/extensions/migration/ui.frontend/src/styles/migration.css
@@ -1,9 +1,4 @@
-:root {
-  /* Adobe Clean is proprietary; use an open fallback stack with the Spectrum look. */
-  --spectrum-sans-font-family-stack: 'Source Sans 3', 'Source Sans Pro', system-ui, -apple-system, 'Segoe UI',
-    Roboto, Helvetica, Arial, sans-serif;
-  --spectrum-code-font-family-stack: 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-}
+@import '@console/styles/tokens.css';
 
 html,
 body {
@@ -41,10 +36,20 @@ body {
 }
 
 .gcm-brand {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
   font-weight: 700;
   font-size: 16px;
   color: var(--spectrum-gray-800);
   text-decoration: none;
+}
+
+.gcm-brand-context,
+.gcm-brand-sep {
+  font-weight: 400;
+  font-size: 14px;
+  color: var(--spectrum-gray-600);
 }
 
 .gcm-app-bar-actions {

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportsPageServlet.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportsPageServlet.groovy
@@ -1,16 +1,9 @@
 package be.orbinson.aem.groovy.console.reports.servlets
 
-import groovy.json.JsonBuilder
-import groovy.util.logging.Slf4j
-import org.apache.sling.api.SlingHttpServletRequest
-import org.apache.sling.api.SlingHttpServletResponse
-import org.apache.sling.api.servlets.SlingSafeMethodsServlet
+import be.orbinson.aem.groovy.console.api.AbstractConsoleUiPageServlet
 import org.osgi.service.component.annotations.Component
 
 import javax.servlet.Servlet
-import javax.servlet.ServletException
-
-import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.CHARSET
 
 /**
  * Serves the business-facing reports UI shell at <code>/apps/groovyconsole/reports.html</code>.
@@ -21,35 +14,25 @@ import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.
 @Component(service = Servlet, immediate = true, property = [
         "sling.servlet.paths=/apps/groovyconsole/reports"
 ])
-@Slf4j("LOG")
-class ReportsPageServlet extends SlingSafeMethodsServlet {
-
-    private static final String ASSETS_PATH = "/apps/groovyconsole-reports/spa/assets"
+class ReportsPageServlet extends AbstractConsoleUiPageServlet {
 
     @Override
-    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
-            throws ServletException, IOException {
-        def contextPath = request.contextPath ?: ""
-        def configJson = new JsonBuilder([contextPath: contextPath]).toString()
+    protected String getPageTitle() {
+        "Reports"
+    }
 
-        response.contentType = "text/html"
-        response.characterEncoding = CHARSET
+    @Override
+    protected String getAssetsPath() {
+        "/apps/groovyconsole-reports/spa/assets"
+    }
 
-        response.writer.write("""\
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Reports</title>
-    <link rel="stylesheet" href="${contextPath}${ASSETS_PATH}/reports.css"/>
-</head>
-<body>
-<gcr-app></gcr-app>
-<script>window.__GC_CONFIG__ = ${configJson};</script>
-<script type="module" src="${contextPath}${ASSETS_PATH}/reports.js"></script>
-</body>
-</html>
-""")
+    @Override
+    protected String getAppElement() {
+        "gcr-app"
+    }
+
+    @Override
+    protected String getAssetName() {
+        "reports"
     }
 }

--- a/extensions/reports/ui.apps/pom.xml
+++ b/extensions/reports/ui.apps/pom.xml
@@ -31,9 +31,14 @@
                     <validatorsSettings>
                         <jackrabbit-filter>
                             <options>
-                                <validRoots>/apps,/apps/cq/core/content/nav/tools</validRoots>
+                                <validRoots>/apps,/apps/cq/core/content</validRoots>
                             </options>
                         </jackrabbit-filter>
+                        <jackrabbit-packagetype>
+                            <options>
+                                <allowComplexFilterRulesInApplicationPackages>true</allowComplexFilterRulesInApplicationPackages>
+                            </options>
+                        </jackrabbit-packagetype>
                     </validatorsSettings>
                 </configuration>
             </plugin>

--- a/extensions/reports/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/extensions/reports/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
-    <!-- AEM Tools console entry so business users can reach the reports UI (overlay; AEM-only) -->
-    <filter root="/apps/cq/core/content/nav/tools/groovyconsole" mode="merge"/>
+    <!-- AEM Tools > General entry so business users can reach the reports UI (overlay; AEM-only).
+         Fine-grained includes so other entries under the shared nav nodes are left untouched. -->
+    <filter root="/apps/cq/core/content/nav">
+        <include pattern="/apps/cq/core/content/nav"/>
+        <include pattern="/apps/cq/core/content/nav/tools"/>
+        <include pattern="/apps/cq/core/content/nav/tools/general"/>
+        <include pattern="/apps/cq/core/content/nav/tools/general/groovyconsole-reports(.*)?"/>
+    </filter>
     <!-- the reports SPA assets (built by extensions/reports/ui.frontend), on a reports-owned path -->
     <filter root="/apps/groovyconsole-reports"/>
 </workspaceFilter>

--- a/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/.content.xml
+++ b/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/.content.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-          jcr:primaryType="nt:unstructured"
-          jcr:title="Groovy Console"
-          id="cq-tools-groovyconsole"/>
+    jcr:primaryType="sling:OrderedFolder"/>

--- a/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/core/content/.content.xml
+++ b/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/core/content/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OrderedFolder"/>

--- a/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/.content.xml
+++ b/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OrderedFolder"/>

--- a/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/.content.xml
+++ b/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OrderedFolder"/>

--- a/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/general/.content.xml
+++ b/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/general/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OrderedFolder"/>

--- a/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/general/groovyconsole-reports/.content.xml
+++ b/extensions/reports/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/general/groovyconsole-reports/.content.xml
@@ -3,6 +3,6 @@
           jcr:primaryType="nt:unstructured"
           jcr:title="Reports"
           jcr:description="Browse, run and export Groovy Console reports"
-          id="cq-tools-groovyconsole-reports"
+          id="granite-general-groovyconsole-reports"
           href="/apps/groovyconsole/reports.html"
-          icon="documentChart"/>
+          icon="graphBarVertical"/>

--- a/extensions/reports/ui.frontend/package-lock.json
+++ b/extensions/reports/ui.frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "aem-groovy-console-reports-ui-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/source-code-pro": "^5.2.7",
+        "@fontsource/source-sans-3": "^5.2.9",
         "@spectrum-web-components/action-button": "^1.7.0",
         "@spectrum-web-components/badge": "^1.12.1",
         "@spectrum-web-components/button": "^1.7.0",
@@ -583,6 +585,24 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/source-code-pro": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-code-pro/-/source-code-pro-5.2.7.tgz",
+      "integrity": "sha512-7papq9TH94KT+S5VSY8cU7tFmwuGkIe3qxXRMscuAXH6AjMU+KJI75f28FzgBVDrlMfA0jjlTV4/x5+H5o/5EQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/source-sans-3": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-3/-/source-sans-3-5.2.9.tgz",
+      "integrity": "sha512-u3ymIq4rfmCCyB9MEw/sFR5lPVJ1yTNXmIMbUz+9kVCFIHvNtfzXOEBuvkg3Tk0zhmioPeJ28ZK5smZ7TurezQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",

--- a/extensions/reports/ui.frontend/package.json
+++ b/extensions/reports/ui.frontend/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/source-code-pro": "^5.2.7",
+    "@fontsource/source-sans-3": "^5.2.9",
     "@spectrum-web-components/action-button": "^1.7.0",
     "@spectrum-web-components/badge": "^1.12.1",
     "@spectrum-web-components/button": "^1.7.0",

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-app.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-app.ts
@@ -1,6 +1,8 @@
 import { html, LitElement, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { config } from '@console/config';
 import { persistence } from '@console/state/local-storage';
+import '@console/components/gc-aem-nav';
 
 type View = { view: 'list' } | { view: 'run'; name: string } | { view: 'edit'; name: string | null };
 
@@ -48,14 +50,23 @@ export class GcrApp extends LitElement {
   private toggleColorScheme(): void {
     this.colorScheme = this.colorScheme === 'dark' ? 'light' : 'dark';
     persistence.saveColorScheme(this.colorScheme);
+    // tell the lazy-loaded Monaco editor (if present) to follow, without importing it here
+    window.dispatchEvent(
+      new CustomEvent('gc-color-scheme-changed', { detail: { colorScheme: this.colorScheme } }),
+    );
   }
 
   protected render() {
     return html`
       <sp-theme class="gcr-root-theme" system="spectrum" color=${this.colorScheme} scale="medium">
         <div class="gcr-frame">
+          ${config.aem ? html`<gc-aem-nav></gc-aem-nav>` : nothing}
           <header class="gcr-app-bar">
-            <a class="gcr-brand" href="#/">Reports</a>
+            <a class="gcr-brand" href="#/">
+              <span class="gcr-brand-context">Groovy Console</span>
+              <span class="gcr-brand-sep">/</span>
+              Reports
+            </a>
             <div class="gcr-app-bar-actions">
               <sp-switch
                 ?checked=${this.colorScheme === 'dark'}

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-code-editor.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-code-editor.ts
@@ -3,7 +3,8 @@ import { customElement, property } from 'lit/decorators.js';
 import type * as Monaco from 'monaco-editor';
 import { attachGroovyDiagnostics } from '@console/editor/groovy-diagnostics';
 import { GROOVY_LANGUAGE_ID } from '@console/editor/groovy-language';
-import { monaco, setupMonaco } from '@console/editor/monaco-setup';
+import { EDITOR_FONT_FAMILY, monaco, setupMonaco, syncMonacoTheme } from '@console/editor/monaco-setup';
+import { persistence } from '@console/state/local-storage';
 
 /**
  * Standalone Monaco Groovy editor for the reports editor view.  Unlike gc-script-editor it has no
@@ -32,6 +33,7 @@ export class GcrCodeEditor extends LitElement {
 
   protected firstUpdated(): void {
     setupMonaco();
+    syncMonacoTheme(persistence.getColorScheme());
 
     const container = this.querySelector<HTMLDivElement>('.gcr-editor-container')!;
 
@@ -42,6 +44,7 @@ export class GcrCodeEditor extends LitElement {
       minimap: { enabled: false },
       scrollBeyondLastLine: false,
       fontSize: 13,
+      fontFamily: EDITOR_FONT_FAMILY,
       fixedOverflowWidgets: true,
       tabSize: 4,
       quickSuggestions: { other: true, comments: false, strings: true },

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-path-browser.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-path-browser.ts
@@ -194,6 +194,14 @@ export class GcrPathBrowser extends LitElement {
     }
   }
 
+  /** Double click selects and confirms in one gesture, like the Granite path pickers. */
+  private onRowDblClick(node: BrowseNode): void {
+    if (node.selectable) {
+      this.selected = node.path;
+      this.confirm();
+    }
+  }
+
   /** Nodes currently visible in the tree, in display order (root children + expanded descendants). */
   private visibleNodes(): BrowseNode[] {
     const out: BrowseNode[] = [];
@@ -300,7 +308,9 @@ export class GcrPathBrowser extends LitElement {
         >
           <header class="gcr-browser-header">
             <h2>${TITLE[this.pathType]}</h2>
-            <sp-action-button quiet label="Close" aria-label="Close" @click=${() => this.close()}>✕</sp-action-button>
+            <sp-action-button quiet label="Close" aria-label="Close" @click=${() => this.close()}>
+              <sp-icon-close slot="icon"></sp-icon-close>
+            </sp-action-button>
           </header>
 
           <div
@@ -353,9 +363,10 @@ export class GcrPathBrowser extends LitElement {
           aria-selected=${this.selected === node.path}
           aria-expanded=${node.hasChildren ? String(isExpanded) : nothing}
           @click=${() => this.onRowClick(node)}
+          @dblclick=${() => this.onRowDblClick(node)}
         >
           <span
-            class="gcr-browser-twisty ${node.hasChildren ? '' : 'is-leaf'}"
+            class="gcr-browser-twisty ${node.hasChildren ? '' : 'is-leaf'} ${isExpanded ? 'is-expanded' : ''}"
             aria-hidden="true"
             @click=${(event: Event) => {
               event.stopPropagation();
@@ -363,7 +374,7 @@ export class GcrPathBrowser extends LitElement {
                 void this.toggle(node);
               }
             }}
-            >${node.hasChildren ? (isExpanded ? '▾' : '▸') : ''}</span
+            >${node.hasChildren ? html`<sp-icon-chevron-right size="xs"></sp-icon-chevron-right>` : ''}</span
           >
           <span class="gcr-browser-name">${node.title || node.name}</span>
           ${node.title ? html`<span class="gcr-browser-subtle">${node.name}</span>` : nothing}

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
@@ -361,7 +361,8 @@ export class GcrReportEditor extends LitElement {
         <div class="gcr-panel-header">
           <h3>Try it out</h3>
           <sp-button size="s" ?disabled=${this.previewing} @click=${() => void this.runPreview()}>
-            ${this.previewing ? 'Running…' : 'Run ▶'}
+            <sp-icon-play slot="icon"></sp-icon-play>
+            ${this.previewing ? 'Running…' : 'Run'}
           </sp-button>
         </div>
 
@@ -523,7 +524,7 @@ export class GcrReportEditor extends LitElement {
           Required
         </sp-checkbox>
         <sp-action-button size="s" quiet @click=${() => this.removeParameter(index)} aria-label="Remove parameter">
-          ✕
+          <sp-icon-close slot="icon"></sp-icon-close>
         </sp-action-button>
       </div>
     `;

--- a/extensions/reports/ui.frontend/src/extensions/reports/gc-reports.ts
+++ b/extensions/reports/ui.frontend/src/extensions/reports/gc-reports.ts
@@ -155,7 +155,7 @@ export class GcReports extends LitElement {
           @submit=${(event: Event) => event.preventDefault()}
         ></sp-search>
         <sp-action-button size="s" quiet @click=${() => void this.refresh()} title="Refresh" aria-label="Refresh">
-          ↻
+          <sp-icon-refresh slot="icon"></sp-icon-refresh>
         </sp-action-button>
         ${this.canManage
           ? html`

--- a/extensions/reports/ui.frontend/src/reports-main.ts
+++ b/extensions/reports/ui.frontend/src/reports-main.ts
@@ -1,4 +1,11 @@
 // Business-facing reports UI entry point.
+// Bundled open fonts matching the Spectrum look (see @console tokens.css font stacks)
+import '@fontsource/source-sans-3/400.css';
+import '@fontsource/source-sans-3/600.css';
+import '@fontsource/source-sans-3/700.css';
+import '@fontsource/source-code-pro/400.css';
+import '@fontsource/source-code-pro/600.css';
+
 // Spectrum Web Components — per-component imports only (bundle size)
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/theme-light.js';
@@ -18,6 +25,10 @@ import '@spectrum-web-components/checkbox/sp-checkbox.js';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/help-text/sp-help-text.js';
 import '@spectrum-web-components/badge/sp-badge.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-close.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-refresh.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-play.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-chevron-right.js';
 
 // App styles
 import './styles/reports.css';

--- a/extensions/reports/ui.frontend/src/styles/reports.css
+++ b/extensions/reports/ui.frontend/src/styles/reports.css
@@ -1,9 +1,4 @@
-:root {
-  /* Adobe Clean is proprietary; use an open fallback stack with the Spectrum look. */
-  --spectrum-sans-font-family-stack: 'Source Sans 3', 'Source Sans Pro', system-ui, -apple-system, 'Segoe UI',
-    Roboto, Helvetica, Arial, sans-serif;
-  --spectrum-code-font-family-stack: 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-}
+@import '@console/styles/tokens.css';
 
 html,
 body {
@@ -41,10 +36,20 @@ body {
 }
 
 .gcr-brand {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
   font-weight: 700;
   font-size: 16px;
   color: var(--spectrum-gray-800);
   text-decoration: none;
+}
+
+.gcr-brand-context,
+.gcr-brand-sep {
+  font-weight: 400;
+  font-size: 14px;
+  color: var(--spectrum-gray-600);
 }
 
 .gcr-app-bar-actions {
@@ -346,10 +351,18 @@ body {
 .gcr-browser-twisty {
   display: inline-flex;
   justify-content: center;
+  align-items: center;
   width: 14px;
   flex-shrink: 0;
   color: var(--spectrum-gray-600);
-  font-size: 11px;
+}
+
+.gcr-browser-twisty sp-icon-chevron-right {
+  transition: transform 130ms ease-out;
+}
+
+.gcr-browser-twisty.is-expanded sp-icon-chevron-right {
+  transform: rotate(90deg);
 }
 
 .gcr-browser-twisty:not(.is-leaf) {
@@ -382,7 +395,7 @@ body {
 }
 
 .gcr-browser-selected {
-  font-family: monospace;
+  font-family: var(--spectrum-code-font-family-stack);
   font-size: 12px;
   color: var(--spectrum-gray-700);
   overflow: hidden;

--- a/ui.frontend/package-lock.json
+++ b/ui.frontend/package-lock.json
@@ -8,7 +8,10 @@
       "name": "aem-groovy-console-ui-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/source-code-pro": "^5.2.7",
+        "@fontsource/source-sans-3": "^5.2.9",
         "@spectrum-web-components/action-button": "^1.7.0",
+        "@spectrum-web-components/action-menu": "^1.12.2",
         "@spectrum-web-components/badge": "^1.12.1",
         "@spectrum-web-components/button": "^1.7.0",
         "@spectrum-web-components/checkbox": "^1.7.0",
@@ -587,6 +590,24 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@fontsource/source-code-pro": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-code-pro/-/source-code-pro-5.2.7.tgz",
+      "integrity": "sha512-7papq9TH94KT+S5VSY8cU7tFmwuGkIe3qxXRMscuAXH6AjMU+KJI75f28FzgBVDrlMfA0jjlTV4/x5+H5o/5EQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/source-sans-3": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-3/-/source-sans-3-5.2.9.tgz",
+      "integrity": "sha512-u3ymIq4rfmCCyB9MEw/sFR5lPVJ1yTNXmIMbUz+9kVCFIHvNtfzXOEBuvkg3Tk0zhmioPeJ28ZK5smZ7TurezQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1018,425 +1039,446 @@
       ]
     },
     "node_modules/@spectrum-web-components/action-button": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/action-button/-/action-button-1.12.1.tgz",
-      "integrity": "sha512-4NbPodLkW2C7a6Tz9r7YdFzqhKbL5yV/Tt5GFnPRVfvexawLrlAgTN7odBtaGCVDPH+HAA7bYy/eygR7uNSQ+A==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/action-button/-/action-button-1.12.2.tgz",
+      "integrity": "sha512-iH9gAJhbRAa4D8oxQSXYq8b9uXu7KIT7ZhpEdFYqk0AwMs+doIqLT0EDy9P90BI9nHRZvDWUnQ0pS+nkzbq+0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/button": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/icons-ui": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/button": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-ui": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
+      }
+    },
+    "node_modules/@spectrum-web-components/action-menu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/action-menu/-/action-menu-1.12.2.tgz",
+      "integrity": "sha512-co+8op1RVC2OvIiKVrah333c999zoD92bUi/gzqFA/rFlWJoNoShasiglgdiEZ15DvbDpijbzRqGKtpywLg9oA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@spectrum-web-components/action-button": "1.12.2",
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/field-label": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-workflow": "1.12.2",
+        "@spectrum-web-components/menu": "1.12.2",
+        "@spectrum-web-components/overlay": "1.12.2",
+        "@spectrum-web-components/picker": "1.12.2",
+        "@spectrum-web-components/popover": "1.12.2",
+        "@spectrum-web-components/progress-circle": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2",
+        "@spectrum-web-components/tooltip": "1.12.2",
+        "@spectrum-web-components/tray": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/alert-dialog": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/alert-dialog/-/alert-dialog-1.12.1.tgz",
-      "integrity": "sha512-dFNsgv0RJCu0+T/w5Di1fj3ecMqXg/PpcESzv7jlq/j6b9/a2MGecYj4o9NqY5eh2sBlGFqIfFOoHLT/Eb1NHw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/alert-dialog/-/alert-dialog-1.12.2.tgz",
+      "integrity": "sha512-RBSQEIlmmJ22VmNko7lgRddHV1xp4EUqwHnfXGFeHU3ox2BJteKggXADlTOAjHcnp1J/Z3896Jt/LKujzOXV/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@lit-labs/observers": "2.0.2",
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/button": "1.12.1",
-        "@spectrum-web-components/button-group": "1.12.1",
-        "@spectrum-web-components/divider": "1.12.1",
-        "@spectrum-web-components/icons-workflow": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/button": "1.12.2",
+        "@spectrum-web-components/button-group": "1.12.2",
+        "@spectrum-web-components/divider": "1.12.2",
+        "@spectrum-web-components/icons-workflow": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/badge": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/badge/-/badge-1.12.1.tgz",
-      "integrity": "sha512-cLrcDj08lB3vpurNfckTiRzpsnzjHG4PnUp96FhLqmi/NMkFDfbG3I/xrMhDMR4+0dmnxK7L0rhpeA9kb6WGxQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/badge/-/badge-1.12.2.tgz",
+      "integrity": "sha512-blc33AyYd3O1jhGiITIVYFcbj0Cnc01ipeE9b9N3zI28neTtF7RCe2xnJgQ4thAtxVy82PPcNkACFxLIes+ZHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/base": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/base/-/base-1.12.1.tgz",
-      "integrity": "sha512-/RYwUI/kI5Gxbp4yn7xi9UTtmx9vLdA6i786cig4QpRJflEszykURIOg1VZO24/vE2etuLhyS3ZPJmp4fB7Wgw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/base/-/base-1.12.2.tgz",
+      "integrity": "sha512-7vB3182FqJzRevafUWlFRw/bfM4ZjC+Mmh5Fh0mDmVcP/SohUowrmHsQns1fsQPi+/O8iMP8XbtT7sAFp6ejkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "lit": "^2.5.0 || ^3.1.3"
       }
     },
     "node_modules/@spectrum-web-components/button": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/button/-/button-1.12.1.tgz",
-      "integrity": "sha512-+SXo3bnGZsSCNA77mS2+Xfu26KQQTJD1jjcbNGkPwqVFKTLzKSfpGINY4gEiefVSIDotH1m/W+5Hb+t5ahdW9w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/button/-/button-1.12.2.tgz",
+      "integrity": "sha512-THab5wD0gzF4vOzUrQwvrNoHYk5fvtVHXNlY272YmEMaVGCP/mpqS2Kf5Pbd9sSNKhe5uRn9QRCVve+e4TZjCw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/clear-button": "1.12.1",
-        "@spectrum-web-components/close-button": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/icons-ui": "1.12.1",
-        "@spectrum-web-components/progress-circle": "1.12.1",
-        "@spectrum-web-components/reactive-controllers": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/clear-button": "1.12.2",
+        "@spectrum-web-components/close-button": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-ui": "1.12.2",
+        "@spectrum-web-components/progress-circle": "1.12.2",
+        "@spectrum-web-components/reactive-controllers": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/button-group": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/button-group/-/button-group-1.12.1.tgz",
-      "integrity": "sha512-KH14vRLm1Aa0LCfDYVN86E/ap6bSDagleZsHW/18WFwQKTfBnkVgY5bypMivjtWsE1D79poSO+eo64kpSeukjA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/button-group/-/button-group-1.12.2.tgz",
+      "integrity": "sha512-Pg1+DONJPpDcr99yjaz+250oxyBKz22C6dbTZ1XBH6jcnWcX81vtWvCb5s7WUPc4cqG68De+CbevplPHDBkz4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/button": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/button": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/checkbox": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/checkbox/-/checkbox-1.12.1.tgz",
-      "integrity": "sha512-o5zqSp/C033Lp2Ha6OIUIJupQMRw1exXxn75NbQPOLZuPIuE25jddnct3XJoizHgyAP7or7GPP50yiC9tbIODw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/checkbox/-/checkbox-1.12.2.tgz",
+      "integrity": "sha512-zXNYRwrdpuzXMBBzZUOkG06uELQQDF2C7xMxLCB1dsuLAswodi4yw2VvydsQ6mOmU46Zo8lmX3okEKzkSDU0/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/icons-ui": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-ui": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/clear-button": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/clear-button/-/clear-button-1.12.1.tgz",
-      "integrity": "sha512-1WqHjfyWaGYY2hqSdkilVYxvnstcIYEnIPw7P+0LW+vfKMrMCVcYWcAPiszgVOBAA3IQqXIjlD+wOAWWpJpY1w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/clear-button/-/clear-button-1.12.2.tgz",
+      "integrity": "sha512-iTDs+FQJkHelR+f4Iz3JL+i5ltbI5XHpweFYLn6UgP+tO6hjZfIr1iw6bCaDs1MEHLIJez1a4mYl0aR6orKa6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/close-button": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/close-button/-/close-button-1.12.1.tgz",
-      "integrity": "sha512-TjUWXrWA9Ewfu2XXaWmBAuyRiyPz5gz4Gw+4B6vyxJJUyMj9JFRhTn0HgD5wJfPd1nx/9PxwktgSkipbjH1MVQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/close-button/-/close-button-1.12.2.tgz",
+      "integrity": "sha512-T1owl+MncqZTMapRZvwGI0IRzzYigzDpsGWR4yu4yc8MDD8D9k067KFZeh2Og1o5uzLNMT9jr6qUh795Xk6rtg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/dialog": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/dialog/-/dialog-1.12.1.tgz",
-      "integrity": "sha512-PWHniK0zl4Bw/IuHrrzGRRlixZNioeU1TksuFULFOdhjZdjdeGhuLLBG57VFoGjjS45sKQO9mctWIEE+z/c+4Q==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/dialog/-/dialog-1.12.2.tgz",
+      "integrity": "sha512-Cxnq21HxlMfYqu3v+QUvJ9ENkp/o9TDSKzdimEWdRBX5PRgQaCDGPVgogCr/xqeyNeI9vp6YGRCcm2le9wG1jQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/alert-dialog": "1.12.1",
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/button": "1.12.1",
-        "@spectrum-web-components/button-group": "1.12.1",
-        "@spectrum-web-components/divider": "1.12.1",
-        "@spectrum-web-components/icons-workflow": "1.12.1",
-        "@spectrum-web-components/modal": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1",
-        "@spectrum-web-components/underlay": "1.12.1"
+        "@spectrum-web-components/alert-dialog": "1.12.2",
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/button": "1.12.2",
+        "@spectrum-web-components/button-group": "1.12.2",
+        "@spectrum-web-components/divider": "1.12.2",
+        "@spectrum-web-components/icons-workflow": "1.12.2",
+        "@spectrum-web-components/modal": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2",
+        "@spectrum-web-components/underlay": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/divider": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/divider/-/divider-1.12.1.tgz",
-      "integrity": "sha512-h//ZlDNYLvhgAXn7HT5z6ZDxdv1zBumMiLC6+733y1JrU70oBadneBtB8DjsOTEyEY/mMW54G9T0r/rRtgGbew==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/divider/-/divider-1.12.2.tgz",
+      "integrity": "sha512-SilrSo86s9EqcZGysE+j06QZ2LTDKFZYigiHhfsCsZP/cpcitJVdYg+BZ1S6UpuPvidjlpzTafQO4qu7mQfMnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/field-label": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/field-label/-/field-label-1.12.1.tgz",
-      "integrity": "sha512-LW/3o0MBOWAkVqV49qAH/dGLRKYVkoePKxyUfwZpxseJc+2eef33kNs0rvHiLxppBSqstU3EAfiSl908NmXq9A==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/field-label/-/field-label-1.12.2.tgz",
+      "integrity": "sha512-XZ98+MkyQn5ZX8bOOpZ92ehV0ArrqMnY+r0AzlwABBIXkn1OiHkMk50RF3SFN6UYcb0QvMwT+tUgXkYjppVQbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/icons-ui": "1.12.1",
-        "@spectrum-web-components/reactive-controllers": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-ui": "1.12.2",
+        "@spectrum-web-components/reactive-controllers": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/help-text": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/help-text/-/help-text-1.12.1.tgz",
-      "integrity": "sha512-pNZZsiK8IPHNs+esZan3C5Jx5ElZqm/2nk7KbwseXMx4VZ2mCXs3YpeUESfHKOwmAeiF4mZ90Kql/krqoANCLw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/help-text/-/help-text-1.12.2.tgz",
+      "integrity": "sha512-r8parJrGwPf/FO7CMjfjCpS6reczRX/RDkGuAs2lYNISE3HUoSUV7OL3CSI4eCKeiwhInHgSACpW93t7RRSCQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/icons-workflow": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/icons-workflow": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/icon": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/icon/-/icon-1.12.1.tgz",
-      "integrity": "sha512-HsejJl/69L4eINRkuTUd/x9MeYKQN88UEXc3qBvgbfW4K0SUxZsu2dXVVfKVJUAqBnLZE6x4tIuXY8i2sT8JaA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/icon/-/icon-1.12.2.tgz",
+      "integrity": "sha512-mvnP1wcjdRVQCV73Le0rKJ22EhPi2jb5xAktRaPdYQebH0yjqVV1EvRNB5ZQPLqVzzDz9UzBm2RzOoGDupu+Jg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/iconset": "1.12.1",
-        "@spectrum-web-components/reactive-controllers": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/iconset": "1.12.2",
+        "@spectrum-web-components/reactive-controllers": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/icons-ui": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/icons-ui/-/icons-ui-1.12.1.tgz",
-      "integrity": "sha512-3j/hzzl4uWrs80oseGBCCijCBO/3sMKcdlLe1ObET4A0vd1+HIeI/9NZ3qBR9Bhsu1IrCReU2GpydcNab+ok7A==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/icons-ui/-/icons-ui-1.12.2.tgz",
+      "integrity": "sha512-ibSFBD1gM6NkU+88g7QOPcee8E2JpClwiI/VZ/6EXbvOa/9QvQR23NfcYZIWHu8p3Wh7Lyas4MO+NdKlt6b09g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/iconset": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/iconset": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/icons-workflow": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/icons-workflow/-/icons-workflow-1.12.1.tgz",
-      "integrity": "sha512-VyDUKFnvgawwvKy+9WWjkJNzXEC9pxAbqnDdEMM4dkByiTWhX1QXkTAZaNZlX+vZagnJ9n0oyh+AywFtyUtE/Q==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/icons-workflow/-/icons-workflow-1.12.2.tgz",
+      "integrity": "sha512-r8r5YhaCwlw8D839HIbqZ+G3J1H49/ibbnp4golnfa96u9oY0OTkQIrdpPefrDxgk4eLXAjwovCMQk7hCWtuNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/iconset": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/iconset/-/iconset-1.12.1.tgz",
-      "integrity": "sha512-z8Ja7CEHrJM1VQF3JiFpB9i7zXLCYQqgm+xCR32GSFCCqhWZIqkTqiFlVAdt1e+gEpkv09KVHGaKWvzMBznhcg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/iconset/-/iconset-1.12.2.tgz",
+      "integrity": "sha512-s6BsY6VnZQOcTx8LfLixdu16g0QXr54wC4PiY7wKcgqkS+VJzo3Up02y7nUUcga38tDb2XcYHZU3rqKVagz6zQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/menu": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/menu/-/menu-1.12.1.tgz",
-      "integrity": "sha512-0ZNlXrMPs7b9+iNADkKDP4aKE8CRfuWp0yYJVirao653qJO6+iFLQKizOWzkCAVEPXHs+kA2O/1EfaiY+VDb2Q==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/menu/-/menu-1.12.2.tgz",
+      "integrity": "sha512-lPdn5TXVfLWXm+O1Y6orhCEEqsiXl2SokRgAFunxFvnUTStp/fgTzwATeSlB71iSd+VN3k8h9NuvCIXkyC7W4A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@lit-labs/observers": "2.0.2",
-        "@spectrum-web-components/action-button": "1.12.1",
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/divider": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/icons-ui": "1.12.1",
-        "@spectrum-web-components/overlay": "1.12.1",
-        "@spectrum-web-components/popover": "1.12.1",
-        "@spectrum-web-components/reactive-controllers": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/action-button": "1.12.2",
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/divider": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-ui": "1.12.2",
+        "@spectrum-web-components/overlay": "1.12.2",
+        "@spectrum-web-components/popover": "1.12.2",
+        "@spectrum-web-components/reactive-controllers": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/modal": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/modal/-/modal-1.12.1.tgz",
-      "integrity": "sha512-J2LHMVydOuSW2E9yDGRkO1BFZv80NlJ3vM5/Jd+n5OlncUnBHC+nZxgudzLSvjxgcM1tDbq11gfjQUUDT5i3hQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/modal/-/modal-1.12.2.tgz",
+      "integrity": "sha512-p5HfcR2V5KtsPuX3JPVOI6h2IHPv/tEN+8mXju551sf/jJDosa4F8Heg7xY39U9xhqg1nLEdP3vPGYo2ynJwzg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/overlay": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/overlay/-/overlay-1.12.1.tgz",
-      "integrity": "sha512-2KQUolmfMVyUMjxVZi2GWjEINaWZsCMnnvK8BV6gpY8G12XUt6uBfP5ubitWiqCXuzWmN1fDEbFdPv1G1c6l2g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/overlay/-/overlay-1.12.2.tgz",
+      "integrity": "sha512-yYGo8MtN6NJMDVU5e8fm6w3G4Gc7XZXaCWEtDXwJD3s3Pw9FZnWWraxbGlIRswBwCjR67RJ17pdG320fo0HhVA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/dom": "1.7.4",
         "@floating-ui/utils": "0.2.10",
-        "@spectrum-web-components/action-button": "1.12.1",
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/reactive-controllers": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1",
-        "@spectrum-web-components/theme": "1.12.1",
+        "@spectrum-web-components/action-button": "1.12.2",
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/reactive-controllers": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2",
+        "@spectrum-web-components/theme": "1.12.2",
         "focus-trap": "7.6.5"
       }
     },
     "node_modules/@spectrum-web-components/picker": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/picker/-/picker-1.12.1.tgz",
-      "integrity": "sha512-woO6n9x3NDhPnRephHhVtaJllDq3Jq0qjjtkRW9iijTw5c3GtxDHsWv/OcdxNHMXgqrMhT4IDGA4nrYpjaJ+jw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/picker/-/picker-1.12.2.tgz",
+      "integrity": "sha512-WJsf1zBtic6wMNXNjMu6/vEwumrDzvG+qq/Q60T7/8dna9XGmDtwVyRWPzYiKwuzXzOCtF+fjG2R9tbyYxmoFQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/button": "1.12.1",
-        "@spectrum-web-components/field-label": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/icons-ui": "1.12.1",
-        "@spectrum-web-components/icons-workflow": "1.12.1",
-        "@spectrum-web-components/menu": "1.12.1",
-        "@spectrum-web-components/overlay": "1.12.1",
-        "@spectrum-web-components/popover": "1.12.1",
-        "@spectrum-web-components/progress-circle": "1.12.1",
-        "@spectrum-web-components/reactive-controllers": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1",
-        "@spectrum-web-components/tooltip": "1.12.1",
-        "@spectrum-web-components/tray": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/button": "1.12.2",
+        "@spectrum-web-components/field-label": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-ui": "1.12.2",
+        "@spectrum-web-components/icons-workflow": "1.12.2",
+        "@spectrum-web-components/menu": "1.12.2",
+        "@spectrum-web-components/overlay": "1.12.2",
+        "@spectrum-web-components/popover": "1.12.2",
+        "@spectrum-web-components/progress-circle": "1.12.2",
+        "@spectrum-web-components/reactive-controllers": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2",
+        "@spectrum-web-components/tooltip": "1.12.2",
+        "@spectrum-web-components/tray": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/popover": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/popover/-/popover-1.12.1.tgz",
-      "integrity": "sha512-Z+/bXO5zq75h5m/phSzEIYx/lAX09WQxMs/SKgE58cjR0BIdJKT4CIodzlbNW0MXI8bcxqhdWa0suHdEtC/VJQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/popover/-/popover-1.12.2.tgz",
+      "integrity": "sha512-lZ2A/IgL3tOFy8/quDae16M+CIjnY56VnabLPcCl9WjX/F9BWMNk88YH5Hr+q6S4U26IueOAjAYg6vWuvZY1oA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/overlay": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/overlay": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/progress-circle": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/progress-circle/-/progress-circle-1.12.1.tgz",
-      "integrity": "sha512-VS9KaexgkM8ZGTrOsR41FFIhtNtB+TzfrxbcGIh4yDAV1KhqhFyo0BnHNtIZFdqaLfjL4recNCRd9g7jqfEaTA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/progress-circle/-/progress-circle-1.12.2.tgz",
+      "integrity": "sha512-I7gAZM8gza/gDZ+tJuKcWF8lld4030GcJpLcySb1NTzBpJlnIItPuybBolSpSb+QzmFTAnlGJaRWTXPZkC8hwA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/reactive-controllers": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/reactive-controllers": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/reactive-controllers": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/reactive-controllers/-/reactive-controllers-1.12.1.tgz",
-      "integrity": "sha512-yhyhl9A8qYpSxlGHrzTRPMhIC1mybtleNaRMbe1V4kldVRAT2d7iSptKX4Qe04QuXzLrx0s4vf/XeGOSXdRHNQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/reactive-controllers/-/reactive-controllers-1.12.2.tgz",
+      "integrity": "sha512-TD94tuA5XDK8ISUM4pWHxJF9oe/IvSHYoR/4P6aYsAj8oPZgrGerNh1a+vzQZ0PorRpVMV4Rg/UHCbtTwxOgOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/progress-circle": "1.12.1",
+        "@spectrum-web-components/progress-circle": "1.12.2",
         "colorjs.io": "0.5.2",
         "lit": "^2.5.0 || ^3.1.3"
       }
     },
     "node_modules/@spectrum-web-components/search": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/search/-/search-1.12.1.tgz",
-      "integrity": "sha512-fFKZaxjnVEIbRaLfnRVXKNC0DEW2+BdxPuxZNwNKfCyVuSwjp05LhMmRJYKAKH4nB+QD+nsEvqob6Up1H/vAUA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/search/-/search-1.12.2.tgz",
+      "integrity": "sha512-d4kpflcg2m2023CvjR1sn5naeF29T3Q1OyPdfjmKVZbz7sCU5Tc67do4ggZM52DOW6wm4pC5cNDSBOgp+CmiQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/button": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/icons-workflow": "1.12.1",
-        "@spectrum-web-components/textfield": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/button": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-workflow": "1.12.2",
+        "@spectrum-web-components/textfield": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/shared": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/shared/-/shared-1.12.1.tgz",
-      "integrity": "sha512-eikz+xVMXKBlLPG7ImoClvwgWCtqpqBnFSRfM0hXJ1oHt9x3axOG17Oh1stZnyRAfFAwCeMPuXg8lMCSQM//Iw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/shared/-/shared-1.12.2.tgz",
+      "integrity": "sha512-1vRimMtdKllujoFPbuDoPP0eSHZJfExWld2jeqboMKjzNTDvBfoOIN3ZOz7ClOVyrJOQDJSP2htCVfDBYl72Ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@lit-labs/observers": "2.0.2",
-        "@spectrum-web-components/base": "1.12.1",
+        "@spectrum-web-components/base": "1.12.2",
         "focus-visible": "5.2.1"
       }
     },
     "node_modules/@spectrum-web-components/styles": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/styles/-/styles-1.12.1.tgz",
-      "integrity": "sha512-MoTw/7D8YQnNDvUbeeLNIaT10TCFOy4++OIrwcPIoTVuZP9TjEIHbLuWXL638nl4yEKpykl22w2Gqyj2ELExbA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/styles/-/styles-1.12.2.tgz",
+      "integrity": "sha512-6vYe/VEbjJ4VDcOSbjxEZaKatwRdxp6yLgEf+qtlo7YOSTAM2016kr6MaqV3EbKXBsVJP8qe9j2hoq29MLGqyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
+        "@spectrum-web-components/base": "1.12.2",
         "lit": "^2.5.0 || ^3.1.3"
       }
     },
     "node_modules/@spectrum-web-components/switch": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/switch/-/switch-1.12.1.tgz",
-      "integrity": "sha512-6XU/Pp15GyE6e9ap0DrHdwwEeqQ1GAsDrzoEY3V94huHQmRGHeSlTp6lgBUUAYl9cXEKeHLpEkECdQW3eE35Rw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/switch/-/switch-1.12.2.tgz",
+      "integrity": "sha512-SDOcY3U+eFGD2Zb1j7Jgig2rbQqYZ1IyilqhvIipcWGseQz36pj8TAhxv/joveX0wTn2/xn4BfP0wxXN/vTA7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/checkbox": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/checkbox": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/table": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/table/-/table-1.12.1.tgz",
-      "integrity": "sha512-Fmm33IPir8XIO4YZhiz+J2QGTkVWINOOpzkP+9Sdsdzqhhb+J6HrOEAa4kaOk1MUOLkFc4xijwN7wVSjjuljLA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/table/-/table-1.12.2.tgz",
+      "integrity": "sha512-+ktIb2sdkfN/B8mAbhoqdciIiUZQF7IwCoCKc7+7coWoDCsFWHJFuM7sgyLuVDV/5liXoenF5qy+8DlHjDLpbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@lit-labs/observers": "2.0.2",
         "@lit-labs/virtualizer": "2.0.12",
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/checkbox": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/icons-ui": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/checkbox": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-ui": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/textfield": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/textfield/-/textfield-1.12.1.tgz",
-      "integrity": "sha512-JrXuUUasMbqDGXomkr+QIRsShWDlgINdlWG6qzW7dmhzSaN0IGtBj+tNZH8fHdNvIocLAyDsKyC01bB3o2iuUw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/textfield/-/textfield-1.12.2.tgz",
+      "integrity": "sha512-FGms1SeWy9dNP8tK8+NUJYNK2kopWLVnyxYSB148UQW/SxRqnlgmkmP4Sofn94C3VzyVURW3cLWTLxCKS5HGAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/help-text": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/icons-ui": "1.12.1",
-        "@spectrum-web-components/icons-workflow": "1.12.1",
-        "@spectrum-web-components/overlay": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1",
-        "@spectrum-web-components/tooltip": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/help-text": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-ui": "1.12.2",
+        "@spectrum-web-components/icons-workflow": "1.12.2",
+        "@spectrum-web-components/overlay": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2",
+        "@spectrum-web-components/tooltip": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/theme": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/theme/-/theme-1.12.1.tgz",
-      "integrity": "sha512-zM83OQi3KcAjgvl+4A2JL3wBpdtVCB3v+zvH3MX3P11KJmPzjoUyTTQ/BnrpTWVOI7KB/ExgvUxQi3i7T2sXmQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/theme/-/theme-1.12.2.tgz",
+      "integrity": "sha512-JWzjsTybXBevJpFlH3HRD+MbssGu2K3/8hv0THU1Wy7khSxNIvfsCAg1Twjt9qTr7BNgw5gfCdMoMDj0qD7Ilg==",
       "license": "ISC",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/styles": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/styles": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/toast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/toast/-/toast-1.12.1.tgz",
-      "integrity": "sha512-136XWhbimpMG027zMG6UrZtVMUmSxsvw7F0T57qh6YsQtq4XRFRJP2LlOjmwo9YlaLG5ymYuARKp+wAzlQrB8A==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/toast/-/toast-1.12.2.tgz",
+      "integrity": "sha512-9qEFzKMenkqr2yjeVX4DsuOmV8I+cWwcALW5LUwHeaQJBjjJN8JVJqxSLr6Flr0ea6GF0kqmgq0t28EQWVjebg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/button": "1.12.1",
-        "@spectrum-web-components/icon": "1.12.1",
-        "@spectrum-web-components/icons-workflow": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/button": "1.12.2",
+        "@spectrum-web-components/icon": "1.12.2",
+        "@spectrum-web-components/icons-workflow": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/tooltip": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/tooltip/-/tooltip-1.12.1.tgz",
-      "integrity": "sha512-KaU4ZkVeNdaO9qVy43imK49dwuAiCe3gzXIBgZIv8teUo7lf6uFYBKp5lxdFd8cxJXunZgGn5wRCg1SOb6TmZg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/tooltip/-/tooltip-1.12.2.tgz",
+      "integrity": "sha512-Q0tbH/7SuInvizNf8f5IdnIhhI21tjGysLJP6HeK+nVjNHOoA45wrphverXVpeQmMhbek6nPizHoeI6fxToxEg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/overlay": "1.12.1",
-        "@spectrum-web-components/reactive-controllers": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/overlay": "1.12.2",
+        "@spectrum-web-components/reactive-controllers": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/tray": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/tray/-/tray-1.12.1.tgz",
-      "integrity": "sha512-eZzdNgzljQGI3cNFJIKABJ/aR0wJeix5yna6AAqALQ2zdHTnofLvWkbOBFcMxCmKFCYKrZRVcU80rgXG1r5OWQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/tray/-/tray-1.12.2.tgz",
+      "integrity": "sha512-SBxSH1yz/b+OnsUPSCfDa9XXjK3Q0cNBxPU5gURwnbIeZXH0VV0nefZkQXTmkJK3d3B9BpLi8zaJk+cj4L0JaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1",
-        "@spectrum-web-components/modal": "1.12.1",
-        "@spectrum-web-components/reactive-controllers": "1.12.1",
-        "@spectrum-web-components/shared": "1.12.1",
-        "@spectrum-web-components/underlay": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2",
+        "@spectrum-web-components/modal": "1.12.2",
+        "@spectrum-web-components/reactive-controllers": "1.12.2",
+        "@spectrum-web-components/shared": "1.12.2",
+        "@spectrum-web-components/underlay": "1.12.2"
       }
     },
     "node_modules/@spectrum-web-components/underlay": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@spectrum-web-components/underlay/-/underlay-1.12.1.tgz",
-      "integrity": "sha512-rKRS2D+SwXvpobJNrBH7FHX/TWAk6f/MAMsFAQmJmx1ixRQLpILgZ/fEExrYvc65FRYPW6H2xzj0a4ceZw+zog==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@spectrum-web-components/underlay/-/underlay-1.12.2.tgz",
+      "integrity": "sha512-YWGXxBkSg/oCBLYD83Rknlf58gCIee2YOtTTGyEpyGJEsK6Rd7P4s/JV+DjELKMpxFL9yG7P4hMoKGoXJvPQZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spectrum-web-components/base": "1.12.1"
+        "@spectrum-web-components/base": "1.12.2"
       }
     },
     "node_modules/@types/estree": {

--- a/ui.frontend/package.json
+++ b/ui.frontend/package.json
@@ -10,7 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/source-code-pro": "^5.2.7",
+    "@fontsource/source-sans-3": "^5.2.9",
     "@spectrum-web-components/action-button": "^1.7.0",
+    "@spectrum-web-components/action-menu": "^1.12.2",
     "@spectrum-web-components/badge": "^1.12.1",
     "@spectrum-web-components/button": "^1.7.0",
     "@spectrum-web-components/checkbox": "^1.7.0",

--- a/ui.frontend/src/api/console-api.ts
+++ b/ui.frontend/src/api/console-api.ts
@@ -42,3 +42,36 @@ export function saveScript(fileName: string, script: string): Promise<unknown> {
 export function loadScript(scriptPath: string): Promise<string> {
   return getText(`${scriptPath}/jcr:content/jcr:data`);
 }
+
+export const SCRIPTS_FOLDER = '/conf/groovyconsole/scripts';
+
+const FOLDER_TYPES = ['sling:Folder', 'sling:OrderedFolder', 'nt:folder'];
+
+export interface FolderListing {
+  folders: string[];
+  files: string[];
+}
+
+/** List the subfolders and script files of a folder below the scripts root (Sling default GET servlet). */
+export async function listScriptsFolder(path: string): Promise<FolderListing> {
+  const folder = await getJson<Record<string, unknown>>(`${path}.1.json`);
+  const folders: string[] = [];
+  const files: string[] = [];
+
+  for (const [name, value] of Object.entries(folder)) {
+    if (typeof value !== 'object' || value === null) {
+      continue;
+    }
+    const primaryType = (value as Record<string, unknown>)['jcr:primaryType'] as string;
+
+    if (primaryType === 'nt:file') {
+      files.push(name);
+    } else if (FOLDER_TYPES.includes(primaryType)) {
+      folders.push(name);
+    }
+  }
+
+  folders.sort((a, b) => a.localeCompare(b));
+  files.sort((a, b) => a.localeCompare(b));
+  return { folders, files };
+}

--- a/ui.frontend/src/components/gc-aem-nav.ts
+++ b/ui.frontend/src/components/gc-aem-nav.ts
@@ -1,0 +1,62 @@
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { config } from '../config';
+
+/**
+ * AEM global-navigation strip shown above the app bar when running on AEM (config.aem), matching the
+ * Coral shell header (48px, #1e1e1e) so the console reads as a regular Tools page. The logo links back
+ * to the AEM start page. Hosts render it conditionally; on plain Sling it is never rendered.
+ */
+@customElement('gc-aem-nav')
+export class GcAemNav extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      flex: none;
+      height: 48px;
+      background: #1e1e1e;
+    }
+
+    a {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      height: 100%;
+      padding: 0 16px;
+      color: #949494;
+      font-size: 14px;
+      text-decoration: none;
+      transition: color 130ms ease-out;
+    }
+
+    a:hover,
+    a:focus-visible {
+      color: #fff;
+    }
+
+    a:focus-visible {
+      outline: 2px solid #378ef0;
+      outline-offset: -2px;
+    }
+
+    svg {
+      width: 22px;
+      height: 19px;
+      flex: none;
+    }
+  `;
+
+  protected render() {
+    return html`
+      <a href="${config.contextPath}/aem/start.html" title="Go to Adobe Experience Manager">
+        <svg viewBox="0 0 30 26" aria-hidden="true">
+          <path
+            fill="#EB1000"
+            d="M19.1 0H30v26L19.1 0zM10.9 0H0v26L10.9 0zM15 9.6 21.9 26h-4.5l-2.1-5.2h-5.1L15 9.6z"
+          />
+        </svg>
+        Adobe Experience Manager
+      </a>
+    `;
+  }
+}

--- a/ui.frontend/src/components/gc-app-bar.ts
+++ b/ui.frontend/src/components/gc-app-bar.ts
@@ -1,5 +1,5 @@
 import { html, LitElement, nothing } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 import { config } from '../config';
 import { StoreController } from '../state/store';
 
@@ -8,31 +8,21 @@ import { StoreController } from '../state/store';
 export class GcAppBar extends LitElement {
   private store = new StoreController(this);
 
-  @state() private menuOpen = false;
-
-  private outsideClickListener = (event: MouseEvent): void => {
-    if (this.menuOpen && !this.contains(event.target as Node)) {
-      this.menuOpen = false;
-    }
-  };
-
   createRenderRoot(): this {
     return this;
   }
 
-  connectedCallback(): void {
-    super.connectedCallback();
-    window.addEventListener('click', this.outsideClickListener);
-  }
-
-  disconnectedCallback(): void {
-    window.removeEventListener('click', this.outsideClickListener);
-    super.disconnectedCallback();
-  }
-
   private emit(name: string): void {
-    this.menuOpen = false;
     this.dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true }));
+  }
+
+  private onMenuChange(event: Event): void {
+    const menu = event.target as HTMLElement & { value: string };
+    const action = menu.value;
+    menu.value = '';
+    if (action) {
+      this.emit(action);
+    }
   }
 
   protected render() {
@@ -60,30 +50,14 @@ export class GcAppBar extends LitElement {
               `
             : nothing}
 
-          <div class="gc-overflow">
-            <sp-action-button
-              quiet
-              aria-label="File actions"
-              aria-haspopup="true"
-              aria-expanded=${this.menuOpen}
-              @click=${(event: Event) => {
-                event.stopPropagation();
-                this.menuOpen = !this.menuOpen;
-              }}
-            >
-              File ▾
-            </sp-action-button>
-            ${this.menuOpen
-              ? html`
-                  <div class="gc-overflow-menu" role="menu">
-                    <button role="menuitem" @click=${() => this.emit('gc-new')}>New</button>
-                    <button role="menuitem" @click=${() => this.emit('gc-open')}>Open…</button>
-                    <button role="menuitem" @click=${() => this.emit('gc-save')}>Save…</button>
-                    <button role="menuitem" @click=${() => this.emit('gc-download')}>Download</button>
-                  </div>
-                `
-              : nothing}
-          </div>
+          <sp-action-menu quiet label="File actions" value="" @change=${this.onMenuChange}>
+            <span slot="label-only">File</span>
+            <sp-menu-item value="gc-new">New</sp-menu-item>
+            <sp-menu-item value="gc-open">Open…</sp-menu-item>
+            <sp-menu-item value="gc-save">Save…</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item value="gc-download">Download</sp-menu-item>
+          </sp-action-menu>
 
           <sp-switch ?checked=${colorScheme === 'dark'} @change=${() => this.emit('gc-toggle-theme')}>
             Dark

--- a/ui.frontend/src/components/gc-app.ts
+++ b/ui.frontend/src/components/gc-app.ts
@@ -27,6 +27,11 @@ type EditorTab = 'script' | 'data';
 const MAX_LIVE_OUTPUT_CHARS = 512 * 1024;
 const LIVE_OUTPUT_TRUNCATION_NOTICE = '… (earlier output truncated; see the full result when the script finishes)\n';
 
+/** Extension modules load asynchronously; sort by title so the rail order is stable across page loads. */
+function sortedPanels(): ConsolePanelExtension[] {
+  return [...getPanels()].sort((a, b) => a.title.localeCompare(b.title));
+}
+
 @customElement('gc-app')
 export class GcApp extends LitElement {
   private store = new StoreController(this);
@@ -84,7 +89,7 @@ export class GcApp extends LitElement {
     this.addEventListener('gc-toast', ((event: CustomEvent<{ message: string; variant?: 'positive' | 'negative' }>) => {
       store.showToast(event.detail.message, event.detail.variant ?? 'positive');
     }) as EventListener);
-    this.unsubscribePanels = onPanelsChanged(() => (this.extensionPanels = [...getPanels()]));
+    this.unsubscribePanels = onPanelsChanged(() => (this.extensionPanels = sortedPanels()));
     this.addEventListener('gc-edit-job', ((event: CustomEvent<{ job: ScheduledJob }>) => {
       this.editScheduledJob(event.detail.job);
     }) as EventListener);
@@ -122,7 +127,7 @@ export class GcApp extends LitElement {
 
     // Load UI extension modules announced by the backend (ConsoleUiExtensionProvider services).
     initConsoleExtensions();
-    this.extensionPanels = [...getPanels()];
+    this.extensionPanels = sortedPanels();
 
     // Deep link from the history panel / classic UI (?userId=...&script=...)
     const auditRecord = config.auditRecord;
@@ -425,7 +430,8 @@ export class GcApp extends LitElement {
 
     return html`
       <sp-theme class="gc-root-theme" system="spectrum" color=${colorScheme} scale="medium">
-        <div class="gc-frame">
+        <div class="gc-frame ${config.aem ? 'gc-frame-aem' : ''}">
+          ${config.aem ? html`<gc-aem-nav></gc-aem-nav>` : nothing}
           <gc-app-bar></gc-app-bar>
 
           <div class="gc-workspace">

--- a/ui.frontend/src/components/gc-data-editor.ts
+++ b/ui.frontend/src/components/gc-data-editor.ts
@@ -1,7 +1,7 @@
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import type * as Monaco from 'monaco-editor';
-import { monaco, setupMonaco } from '../editor/monaco-setup';
+import { EDITOR_FONT_FAMILY, monaco, setupMonaco } from '../editor/monaco-setup';
 import { persistence } from '../state/local-storage';
 
 @customElement('gc-data-editor')
@@ -42,6 +42,7 @@ export class GcDataEditor extends LitElement {
       minimap: { enabled: false },
       scrollBeyondLastLine: false,
       fontSize: 13,
+      fontFamily: EDITOR_FONT_FAMILY,
       fixedOverflowWidgets: true,
       tabSize: 2,
     });

--- a/ui.frontend/src/components/gc-drawer.ts
+++ b/ui.frontend/src/components/gc-drawer.ts
@@ -9,16 +9,22 @@ export class GcDrawer extends LitElement {
       display: contents;
     }
 
+    /* Overlay the workspace only: the app bar and the activity rail stay visible and
+       interactive, so panels can be switched directly from the rail. */
     .backdrop {
       position: fixed;
-      inset: 0;
+      top: var(--gc-drawer-top, 49px);
+      bottom: 0;
+      left: 48px;
+      right: 0;
       background: rgba(0, 0, 0, 0.35);
       z-index: 200;
+      animation: gc-drawer-fade 130ms ease-out;
     }
 
     .panel {
       position: fixed;
-      top: 0;
+      top: var(--gc-drawer-top, 49px);
       bottom: 0;
       left: 48px;
       width: min(960px, calc(100vw - 48px));
@@ -27,15 +33,43 @@ export class GcDrawer extends LitElement {
       background: var(--spectrum-gray-50);
       color: var(--spectrum-gray-800);
       border-right: 1px solid var(--spectrum-gray-300);
-      box-shadow: 4px 0 16px rgba(0, 0, 0, 0.25);
+      box-shadow: 8px 0 24px rgba(0, 0, 0, 0.12);
       z-index: 201;
+      animation: gc-drawer-slide 160ms ease-out;
+    }
+
+    @keyframes gc-drawer-slide {
+      from {
+        transform: translateX(-24px);
+        opacity: 0;
+      }
+      to {
+        transform: translateX(0);
+        opacity: 1;
+      }
+    }
+
+    @keyframes gc-drawer-fade {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .panel,
+      .backdrop {
+        animation: none;
+      }
     }
 
     .header {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 12px 16px;
+      padding: 10px 16px;
       border-bottom: 1px solid var(--spectrum-gray-300);
     }
 
@@ -47,6 +81,7 @@ export class GcDrawer extends LitElement {
     .body {
       flex: 1;
       overflow-y: auto;
+      overflow-x: auto;
       padding: 12px 16px;
     }
   `;
@@ -84,7 +119,9 @@ export class GcDrawer extends LitElement {
       <aside class="panel" role="dialog" aria-label=${this.heading}>
         <div class="header">
           <h3>${this.heading}</h3>
-          <sp-action-button size="s" quiet @click=${this.close} aria-label="Close">✕</sp-action-button>
+          <sp-action-button size="s" quiet @click=${this.close} aria-label="Close">
+            <sp-icon-close slot="icon"></sp-icon-close>
+          </sp-action-button>
         </div>
         <div class="body">
           <slot></slot>

--- a/ui.frontend/src/components/gc-history.ts
+++ b/ui.frontend/src/components/gc-history.ts
@@ -193,7 +193,9 @@ export class GcHistory extends LitElement {
                         <td><code title=${record.script ?? ''}>${record.scriptPreview ?? ''}</code></td>
                         <td>
                           ${record.exception
-                            ? html`<sp-badge size="s" variant="negative">${record.exception}</sp-badge>`
+                            ? html`<sp-badge size="s" variant="negative" title=${record.exception}>
+                                ${record.exception.split('.').pop()}
+                              </sp-badge>`
                             : nothing}
                         </td>
                         <td class="gc-row-actions">

--- a/ui.frontend/src/components/gc-result.ts
+++ b/ui.frontend/src/components/gc-result.ts
@@ -141,7 +141,7 @@ export class GcResult extends LitElement {
         <div class="gc-dock">
           <div class="gc-dock-header">
             <span class="gc-dock-title">Output</span>
-            <sp-badge size="s" variant="informative">● live</sp-badge>
+            <span class="gc-dock-live"><span class="gc-dock-live-dot"></span>Live</span>
           </div>
           <div class="gc-dock-body">
             ${liveOutput.length
@@ -192,7 +192,7 @@ export class GcResult extends LitElement {
             )}
           </div>
           ${response.runningTime?.length
-            ? html`<sp-badge size="s" variant="informative">⏱ ${response.runningTime}</sp-badge>`
+            ? html`<span class="gc-dock-time" title="Running time">${response.runningTime}</span>`
             : nothing}
           <span class="gc-status-spacer"></span>
           ${active

--- a/ui.frontend/src/components/gc-save-dialog.ts
+++ b/ui.frontend/src/components/gc-save-dialog.ts
@@ -1,16 +1,42 @@
 import { html, LitElement, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
+import { listScriptsFolder, SCRIPTS_FOLDER, type FolderListing } from '../api/console-api';
 import { persistence } from '../state/local-storage';
 import { mutePlaceholders } from '../util/mute-placeholders';
 
-/** Save-as dialog: prompts for a file name and emits gc-save-script. */
+/**
+ * Save-as dialog: folder-navigable target picker (same breadcrumb + folder list as the open dialog)
+ * plus a file name field; emits gc-save-script with the folder-relative file name.
+ */
 @customElement('gc-save-dialog')
 export class GcSaveDialog extends LitElement {
   @state() private open = false;
   @state() private fileName = '';
+  @state() private currentPath = SCRIPTS_FOLDER;
+  @state() private listing: FolderListing = { folders: [], files: [] };
+  @state() private loading = false;
 
   createRenderRoot(): this {
     return this;
+  }
+
+  // sp-dialog-wrapper only handles Escape when opened through the Overlay system; rendered inline it
+  // does not, so close on Escape ourselves (same pattern as gc-drawer).
+  private keyListener = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape' && this.open) {
+      this.open = false;
+    }
+  };
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    // capture phase: the Spectrum dialog stops Escape from bubbling
+    window.addEventListener('keydown', this.keyListener, { capture: true });
+  }
+
+  disconnectedCallback(): void {
+    window.removeEventListener('keydown', this.keyListener, { capture: true });
+    super.disconnectedCallback();
   }
 
   protected updated(): void {
@@ -20,10 +46,49 @@ export class GcSaveDialog extends LitElement {
   show(): void {
     this.fileName = persistence.getScriptName() || '';
     this.open = true;
+    void this.navigate(persistence.getSaveFolder() || SCRIPTS_FOLDER);
+  }
+
+  private async navigate(path: string): Promise<void> {
+    this.currentPath = path;
+    this.loading = true;
+
+    try {
+      this.listing = await listScriptsFolder(path);
+    } catch {
+      // folder may not exist yet (e.g. remembered folder was deleted) — fall back to the root
+      if (path !== SCRIPTS_FOLDER) {
+        await this.navigate(SCRIPTS_FOLDER);
+        return;
+      }
+      this.listing = { folders: [], files: [] };
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private get breadcrumbs(): Array<{ label: string; path: string }> {
+    const relative = this.currentPath.slice(SCRIPTS_FOLDER.length).split('/').filter(Boolean);
+    const crumbs = [{ label: 'Scripts', path: SCRIPTS_FOLDER }];
+
+    let path = SCRIPTS_FOLDER;
+    for (const segment of relative) {
+      path = `${path}/${segment}`;
+      crumbs.push({ label: segment, path });
+    }
+
+    return crumbs;
+  }
+
+  /** The file name to submit: current folder (relative to the scripts root) + typed name. */
+  private get relativeFileName(): string {
+    const folder = this.currentPath.slice(SCRIPTS_FOLDER.length).replace(/^\//, '');
+    const name = this.fileName.trim().replace(/^\/+/, '');
+    return folder && name ? `${folder}/${name}` : name;
   }
 
   private confirm(): void {
-    let fileName = this.fileName.trim();
+    let fileName = this.relativeFileName;
 
     if (!fileName) {
       return;
@@ -34,6 +99,7 @@ export class GcSaveDialog extends LitElement {
     }
 
     this.open = false;
+    persistence.saveSaveFolder(this.currentPath);
     this.dispatchEvent(
       new CustomEvent('gc-save-script', { detail: { fileName }, bubbles: true, composed: true }),
     );
@@ -43,6 +109,12 @@ export class GcSaveDialog extends LitElement {
     if (!this.open) {
       return nothing;
     }
+
+    const crumbs = this.breadcrumbs;
+    const name = this.fileName.trim().replace(/^\/+/, '');
+    const targetPath = name
+      ? `${this.currentPath}/${name}${name.endsWith('.groovy') ? '' : '.groovy'}`
+      : '';
 
     return html`
       <sp-dialog-wrapper
@@ -55,6 +127,55 @@ export class GcSaveDialog extends LitElement {
         @cancel=${() => (this.open = false)}
         @close=${() => (this.open = false)}
       >
+        <nav class="gc-browser-breadcrumbs" aria-label="Folder path">
+          ${crumbs.map(
+            (crumb, index) => html`
+              ${index > 0 ? html`<span class="gc-browser-crumb-sep">/</span>` : nothing}
+              ${index === crumbs.length - 1
+                ? html`<span class="gc-browser-crumb is-current">${crumb.label}</span>`
+                : html`
+                    <button class="gc-browser-crumb" @click=${() => void this.navigate(crumb.path)}>
+                      ${crumb.label}
+                    </button>
+                  `}
+            `,
+          )}
+        </nav>
+
+        <div class="gc-browser-list gc-save-folder-list">
+          ${this.loading
+            ? html`<sp-progress-circle indeterminate size="m" aria-label="Loading folders"></sp-progress-circle>`
+            : html`
+                ${this.listing.folders.map(
+                  (folderName) => html`
+                    <button
+                      class="gc-browser-item"
+                      @click=${() => void this.navigate(`${this.currentPath}/${folderName}`)}
+                    >
+                      <sp-icon-folder class="gc-browser-icon" size="s"></sp-icon-folder>
+                      <span class="gc-browser-name">${folderName}</span>
+                      <sp-icon-chevron-right class="gc-browser-chevron" size="xs"></sp-icon-chevron-right>
+                    </button>
+                  `,
+                )}
+                ${this.listing.files.map(
+                  (existingName) => html`
+                    <button
+                      class="gc-browser-item"
+                      title="Use this file name (overwrites on save)"
+                      @click=${() => (this.fileName = existingName)}
+                    >
+                      <sp-icon-file-code class="gc-browser-icon" size="s"></sp-icon-file-code>
+                      <span class="gc-browser-name">${existingName}</span>
+                    </button>
+                  `,
+                )}
+                ${!this.listing.folders.length && !this.listing.files.length
+                  ? html`<p class="gc-muted">This folder is empty.</p>`
+                  : nothing}
+              `}
+        </div>
+
         <sp-field-label for="gc-save-file-name">File Name</sp-field-label>
         <sp-textfield
           id="gc-save-file-name"
@@ -63,6 +184,9 @@ export class GcSaveDialog extends LitElement {
           @input=${(event: Event) => (this.fileName = (event.target as HTMLInputElement).value)}
           @keydown=${(event: KeyboardEvent) => event.key === 'Enter' && this.confirm()}
         ></sp-textfield>
+        ${targetPath
+          ? html`<sp-help-text size="s">Saves to <code>${targetPath}</code></sp-help-text>`
+          : nothing}
       </sp-dialog-wrapper>
     `;
   }

--- a/ui.frontend/src/components/gc-script-browser-dialog.ts
+++ b/ui.frontend/src/components/gc-script-browser-dialog.ts
@@ -1,14 +1,6 @@
 import { html, LitElement, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { getJson } from '../api/client';
-
-const SCRIPTS_FOLDER = '/conf/groovyconsole/scripts';
-const FOLDER_TYPES = ['sling:Folder', 'sling:OrderedFolder', 'nt:folder'];
-
-interface FolderListing {
-  folders: string[];
-  files: string[];
-}
+import { listScriptsFolder, SCRIPTS_FOLDER, type FolderListing } from '../api/console-api';
 
 /**
  * Folder-navigable script browser for opening saved scripts: breadcrumb + folder/file list
@@ -25,6 +17,25 @@ export class GcScriptBrowserDialog extends LitElement {
     return this;
   }
 
+  // sp-dialog-wrapper only handles Escape when opened through the Overlay system; rendered inline it
+  // does not, so close on Escape ourselves (same pattern as gc-drawer).
+  private keyListener = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape' && this.open) {
+      this.open = false;
+    }
+  };
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    // capture phase: the Spectrum dialog stops Escape from bubbling
+    window.addEventListener('keydown', this.keyListener, { capture: true });
+  }
+
+  disconnectedCallback(): void {
+    window.removeEventListener('keydown', this.keyListener, { capture: true });
+    super.disconnectedCallback();
+  }
+
   async show(): Promise<void> {
     this.open = true;
     await this.navigate(SCRIPTS_FOLDER);
@@ -35,26 +46,7 @@ export class GcScriptBrowserDialog extends LitElement {
     this.loading = true;
 
     try {
-      const folder = await getJson<Record<string, unknown>>(`${path}.1.json`);
-      const folders: string[] = [];
-      const files: string[] = [];
-
-      for (const [name, value] of Object.entries(folder)) {
-        if (typeof value !== 'object' || value === null) {
-          continue;
-        }
-        const primaryType = (value as Record<string, unknown>)['jcr:primaryType'] as string;
-
-        if (primaryType === 'nt:file') {
-          files.push(name);
-        } else if (FOLDER_TYPES.includes(primaryType)) {
-          folders.push(name);
-        }
-      }
-
-      folders.sort((a, b) => a.localeCompare(b));
-      files.sort((a, b) => a.localeCompare(b));
-      this.listing = { folders, files };
+      this.listing = await listScriptsFolder(path);
     } catch {
       this.listing = { folders: [], files: [] };
     } finally {
@@ -122,16 +114,16 @@ export class GcScriptBrowserDialog extends LitElement {
                 ${this.listing.folders.map(
                   (name) => html`
                     <button class="gc-browser-item" @click=${() => void this.navigate(`${this.currentPath}/${name}`)}>
-                      <span class="gc-browser-icon">📁</span>
+                      <sp-icon-folder class="gc-browser-icon" size="s"></sp-icon-folder>
                       <span class="gc-browser-name">${name}</span>
-                      <span class="gc-browser-chevron">›</span>
+                      <sp-icon-chevron-right class="gc-browser-chevron" size="xs"></sp-icon-chevron-right>
                     </button>
                   `,
                 )}
                 ${this.listing.files.map(
                   (name) => html`
                     <button class="gc-browser-item" @click=${() => this.select(name)}>
-                      <span class="gc-browser-icon">📄</span>
+                      <sp-icon-file-code class="gc-browser-icon" size="s"></sp-icon-file-code>
                       <span class="gc-browser-name">${name}</span>
                     </button>
                   `,

--- a/ui.frontend/src/components/gc-script-editor.ts
+++ b/ui.frontend/src/components/gc-script-editor.ts
@@ -3,7 +3,7 @@ import { customElement } from 'lit/decorators.js';
 import type * as Monaco from 'monaco-editor';
 import { attachGroovyDiagnostics } from '../editor/groovy-diagnostics';
 import { GROOVY_LANGUAGE_ID } from '../editor/groovy-language';
-import { monaco, setupMonaco } from '../editor/monaco-setup';
+import { EDITOR_FONT_FAMILY, monaco, setupMonaco } from '../editor/monaco-setup';
 import { persistence } from '../state/local-storage';
 import { store } from '../state/store';
 
@@ -53,6 +53,7 @@ export class GcScriptEditor extends LitElement {
       minimap: { enabled: false },
       scrollBeyondLastLine: false,
       fontSize: 13,
+      fontFamily: EDITOR_FONT_FAMILY,
       fixedOverflowWidgets: true,
       tabSize: 4,
       // strings: service-name completion lives inside getService("...") string literals

--- a/ui.frontend/src/components/gc-status-bar.ts
+++ b/ui.frontend/src/components/gc-status-bar.ts
@@ -45,7 +45,6 @@ export class GcStatusBar extends LitElement {
         <span class="gc-status-spacer"></span>
         <span class="gc-status-hint">${MOD}↵ Run</span>
         <span class="gc-status-hint">${MOD}S Save</span>
-        <span class="gc-status-hint">${MOD}K Commands</span>
       </footer>
     `;
   }

--- a/ui.frontend/src/editor/monaco-setup.ts
+++ b/ui.frontend/src/editor/monaco-setup.ts
@@ -16,22 +16,62 @@ self.MonacoEnvironment = {
   },
 };
 
+/** Same code font stack as --spectrum-code-font-family-stack (tokens.css); Monaco needs it explicitly. */
+export const EDITOR_FONT_FAMILY = "'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace";
+
 let initialized = false;
 
 export function setupMonaco(): typeof monaco {
   if (!initialized) {
     initialized = true;
+
+    // Editor themes that sit on the Spectrum surface scale, so the editor reads as a pane
+    // of the app instead of a foreign dark/light rectangle (gray-50 light, gray-100 dark).
+    monaco.editor.defineTheme('gc-light', {
+      base: 'vs',
+      inherit: true,
+      rules: [],
+      colors: {
+        'editor.background': '#ffffff',
+        'editor.lineHighlightBackground': '#f5f5f5',
+        'editorLineNumber.foreground': '#b1b1b1',
+        'editorLineNumber.activeForeground': '#505050',
+        'editorGutter.background': '#ffffff',
+      },
+    });
+    monaco.editor.defineTheme('gc-dark', {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [],
+      colors: {
+        'editor.background': '#1d1d1d',
+        'editor.lineHighlightBackground': '#252525',
+        'editorLineNumber.foreground': '#6e6e6e',
+        'editorLineNumber.activeForeground': '#b1b1b1',
+        'editorGutter.background': '#1d1d1d',
+      },
+    });
+
     registerGroovyLanguage(monaco);
     registerGroovyCompletionProvider(monaco);
     registerGroovyHoverProvider(monaco);
+
+    // Hosts that lazy-load Monaco (reports editor) announce scheme changes via this window
+    // event instead of importing this module eagerly, which would defeat the code split.
+    window.addEventListener('gc-color-scheme-changed', ((event: CustomEvent<{ colorScheme: 'light' | 'dark' }>) => {
+      syncMonacoTheme(event.detail.colorScheme);
+    }) as EventListener);
+
+    // Monaco measures glyph widths at editor creation; if the bundled webfont arrives later,
+    // remeasure so the cursor and selection don't drift from the rendered text.
+    document.fonts?.ready.then(() => monaco.editor.remeasureFonts());
   }
   return monaco;
 }
 
-export function syncMonacoTheme(_colorScheme: 'light' | 'dark'): void {
-  // The editors keep a dark theme in both color schemes, matching the classic console's
-  // default dark editor (idle_fingers) on a light page.
-  monaco.editor.setTheme('vs-dark');
+export function syncMonacoTheme(colorScheme: 'light' | 'dark'): void {
+  setupMonaco();
+  monaco.editor.setTheme(colorScheme === 'dark' ? 'gc-dark' : 'gc-light');
 }
 
 export { monaco };

--- a/ui.frontend/src/main.ts
+++ b/ui.frontend/src/main.ts
@@ -1,3 +1,11 @@
+// Bundled open fonts matching the Spectrum look (Adobe Clean is proprietary); the token
+// font stacks in styles/tokens.css list these families first.
+import '@fontsource/source-sans-3/400.css';
+import '@fontsource/source-sans-3/600.css';
+import '@fontsource/source-sans-3/700.css';
+import '@fontsource/source-code-pro/400.css';
+import '@fontsource/source-code-pro/600.css';
+
 // Spectrum Web Components — per-component imports only (bundle size)
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/theme-light.js';
@@ -20,15 +28,22 @@ import '@spectrum-web-components/checkbox/sp-checkbox.js';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/help-text/sp-help-text.js';
 import '@spectrum-web-components/badge/sp-badge.js';
+import '@spectrum-web-components/action-menu/sp-action-menu.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-history.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-clock.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-help.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-close.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-refresh.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-folder.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-file-code.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-chevron-right.js';
 
 // App styles
 import './styles/app.css';
 
 // Components
 import './components/gc-app';
+import './components/gc-aem-nav';
 import './components/gc-app-bar';
 import './components/gc-status-bar';
 import './components/gc-drawer';

--- a/ui.frontend/src/state/local-storage.ts
+++ b/ui.frontend/src/state/local-storage.ts
@@ -37,7 +37,14 @@ export const persistence = {
 
   // The classic UI stores Ace theme ids ("ace/theme/..."); the modern UI stores
   // "light"/"dark" under its own key to avoid clobbering the classic preference.
-  getColorScheme: (): 'light' | 'dark' => (get(`${THEME}.modern`) === 'dark' ? 'dark' : 'light'),
+  // Without a stored preference, follow the OS color scheme.
+  getColorScheme: (): 'light' | 'dark' => {
+    const stored = get(`${THEME}.modern`);
+    if (stored === 'dark' || stored === 'light') {
+      return stored;
+    }
+    return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  },
   saveColorScheme: (value: 'light' | 'dark'): void => set(`${THEME}.modern`, value),
 
   getSplitterPosition: (): number | null => {
@@ -45,6 +52,10 @@ export const persistence = {
     return value ? Number(value) : null;
   },
   saveSplitterPosition: (value: number): void => set('groovyconsole.modern.splitter', String(value)),
+
+  /** Last folder a script was saved into, so consecutive saves land in the same place. */
+  getSaveFolder: (): string => get('groovyconsole.modern.save.folder'),
+  saveSaveFolder: (path: string): void => set('groovyconsole.modern.save.folder', path),
 
   getScriptName: (): string => get(SCRIPT_NAME),
   saveScriptName: (scriptPath: string): void => {

--- a/ui.frontend/src/styles/app.css
+++ b/ui.frontend/src/styles/app.css
@@ -1,8 +1,9 @@
+@import './tokens.css';
+
 :root {
-  /* Adobe Clean is proprietary; use an open fallback stack with the Spectrum look. */
-  --spectrum-sans-font-family-stack: 'Source Sans 3', 'Source Sans Pro', system-ui, -apple-system, 'Segoe UI',
-    Roboto, Helvetica, Arial, sans-serif;
-  --spectrum-code-font-family-stack: 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --gc-app-bar-height: 49px;
+  /* top offset for the drawer overlay: everything above the workspace (app bar, plus AEM nav when present) */
+  --gc-drawer-top: var(--gc-app-bar-height);
 }
 
 html,
@@ -21,6 +22,16 @@ body {
   font-family: var(--spectrum-sans-font-family-stack);
 }
 
+/* Consistent keyboard focus for the hand-rolled controls (Spectrum components ship their own). */
+.gc-rail-button:focus-visible,
+.gc-pane-tab:focus-visible,
+.gc-dock-tab:focus-visible,
+.gc-browser-crumb:focus-visible,
+.gc-browser-item:focus-visible {
+  outline: 2px solid var(--spectrum-blue-800);
+  outline-offset: -2px;
+}
+
 /* ---- app frame ---- */
 
 .gc-frame {
@@ -29,11 +40,18 @@ body {
   height: 100vh;
 }
 
+/* On AEM the global-nav strip sits above the app bar; drawers must open below both. */
+.gc-frame-aem {
+  --gc-drawer-top: calc(var(--gc-app-bar-height) + 48px);
+}
+
 .gc-app-bar {
+  box-sizing: border-box;
+  height: var(--gc-app-bar-height);
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 8px 16px;
+  padding: 0 16px;
   border-bottom: 1px solid var(--spectrum-gray-300);
   background: var(--spectrum-gray-50);
 }
@@ -65,41 +83,6 @@ body {
   align-items: center;
   gap: 12px;
   margin-inline-start: auto;
-}
-
-.gc-overflow {
-  position: relative;
-}
-
-.gc-overflow-menu {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  min-width: 160px;
-  display: flex;
-  flex-direction: column;
-  background: var(--spectrum-gray-50);
-  border: 1px solid var(--spectrum-gray-300);
-  border-radius: 6px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-  padding: 4px;
-  z-index: 300;
-}
-
-.gc-overflow-menu button {
-  border: none;
-  background: transparent;
-  font: inherit;
-  font-size: 13px;
-  color: var(--spectrum-gray-800);
-  text-align: left;
-  padding: 8px 12px;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.gc-overflow-menu button:hover {
-  background: var(--spectrum-gray-200);
 }
 
 .gc-classic-link {
@@ -140,10 +123,13 @@ body {
   align-items: center;
   justify-content: center;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--gc-radius);
   background: transparent;
   color: var(--spectrum-gray-600);
   cursor: pointer;
+  transition:
+    background var(--gc-transition),
+    color var(--gc-transition);
 }
 
 .gc-rail-button:hover {
@@ -192,15 +178,16 @@ body {
 
 .gc-split-handle {
   flex: none;
-  height: 6px;
+  height: 5px;
   cursor: row-resize;
   background: var(--spectrum-gray-200);
   border-top: 1px solid var(--spectrum-gray-300);
   touch-action: none;
+  transition: background var(--gc-transition);
 }
 
 .gc-split-handle:hover {
-  background: var(--spectrum-blue-400);
+  background: var(--spectrum-blue-500);
 }
 
 .gc-pane-header {
@@ -221,6 +208,9 @@ body {
   padding: 6px 12px;
   cursor: pointer;
   border-bottom: 2px solid transparent;
+  transition:
+    color var(--gc-transition),
+    border-color var(--gc-transition);
 }
 
 .gc-pane-tab:hover,
@@ -271,7 +261,7 @@ gc-data-editor.gc-hidden {
 .gc-dock-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   padding: 2px 12px;
   border-bottom: 1px solid var(--spectrum-gray-300);
   background: var(--spectrum-gray-75);
@@ -289,6 +279,40 @@ gc-data-editor.gc-hidden {
 .gc-dock-tabs {
   display: flex;
   gap: 2px;
+}
+
+.gc-dock-time {
+  font-family: var(--spectrum-code-font-family-stack);
+  font-size: 11px;
+  color: var(--spectrum-gray-600);
+}
+
+.gc-dock-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--spectrum-blue-900);
+}
+
+.gc-dock-live-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--spectrum-blue-900);
+  animation: gc-live-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes gc-live-pulse {
+  50% {
+    opacity: 0.3;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gc-dock-live-dot {
+    animation: none;
+  }
 }
 
 .gc-dock-body {
@@ -371,9 +395,12 @@ gc-data-editor.gc-hidden {
 /* ---- drawers ---- */
 
 .gc-drawer-subheading {
-  margin: 16px 0 4px;
-  font-size: 13px;
+  margin: 20px 0 6px;
+  font-size: 11px;
   font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--spectrum-gray-600);
 }
 
 .gc-drawer-content {
@@ -384,7 +411,7 @@ gc-data-editor.gc-hidden {
 
 .gc-section {
   border: 1px solid var(--spectrum-gray-300);
-  border-radius: 4px;
+  border-radius: var(--gc-radius);
   padding: 8px 16px;
   background-color: var(--spectrum-gray-50);
   margin-bottom: 8px;
@@ -394,6 +421,30 @@ gc-data-editor.gc-hidden {
   cursor: pointer;
   font-weight: 600;
   padding: 4px 0;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.gc-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+/* custom disclosure chevron replacing the native ► marker */
+.gc-section > summary::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-right: 2px solid var(--spectrum-gray-600);
+  border-bottom: 2px solid var(--spectrum-gray-600);
+  transform: rotate(-45deg);
+  transition: transform var(--gc-transition);
+  flex: none;
+}
+
+.gc-section[open] > summary::before {
+  transform: rotate(45deg);
 }
 
 .gc-muted {
@@ -417,9 +468,26 @@ gc-data-editor.gc-hidden {
   vertical-align: middle;
 }
 
+.gc-table tbody tr {
+  transition: background var(--gc-transition);
+}
+
+.gc-table tbody tr:hover {
+  background: var(--spectrum-gray-100);
+}
+
 .gc-table th {
   font-weight: 600;
   color: var(--spectrum-gray-700);
+}
+
+.gc-table a {
+  color: var(--spectrum-blue-900);
+  text-decoration: none;
+}
+
+.gc-table a:hover {
+  text-decoration: underline;
 }
 
 /* keep timestamp links (Date / Next Execution Date) on a single line */
@@ -453,6 +521,16 @@ gc-data-editor.gc-hidden {
   border-radius: 4px;
   background: var(--spectrum-gray-50);
   color: inherit;
+  transition: border-color var(--gc-transition);
+}
+
+.gc-date-input:hover {
+  border-color: var(--spectrum-gray-500);
+}
+
+.gc-date-input:focus-visible {
+  outline: 2px solid var(--spectrum-blue-800);
+  outline-offset: -1px;
 }
 
 .gc-form {
@@ -512,6 +590,7 @@ gc-data-editor.gc-hidden {
   cursor: pointer;
   padding: 2px 4px;
   border-radius: 4px;
+  transition: background var(--gc-transition);
 }
 
 .gc-browser-crumb:hover {
@@ -537,6 +616,15 @@ gc-data-editor.gc-hidden {
   overflow-y: auto;
 }
 
+/* in the save dialog the folder list shares the dialog with the name field — keep it compact */
+.gc-save-folder-list {
+  max-height: 220px;
+  margin-bottom: 12px;
+  border: 1px solid var(--spectrum-gray-300);
+  border-radius: var(--gc-radius);
+  padding: 4px;
+}
+
 .gc-browser-item {
   display: flex;
   align-items: center;
@@ -548,12 +636,18 @@ gc-data-editor.gc-hidden {
   color: var(--spectrum-gray-800);
   text-align: left;
   padding: 8px 10px;
-  border-radius: 6px;
+  border-radius: var(--gc-radius);
   cursor: pointer;
+  transition: background var(--gc-transition);
 }
 
 .gc-browser-item:hover {
   background: var(--spectrum-gray-200);
+}
+
+.gc-browser-icon {
+  flex: none;
+  color: var(--spectrum-gray-600);
 }
 
 .gc-browser-name {

--- a/ui.frontend/src/styles/tokens.css
+++ b/ui.frontend/src/styles/tokens.css
@@ -1,0 +1,16 @@
+/* Shared design tokens for the console and extension UIs (imported via the @console alias). */
+/* The font overrides must also target sp-theme itself: the theme declares its own
+   --spectrum-*-font-family-stack (adobe-clean, …) on :host, which shadows a plain :root
+   declaration for everything inside the theme. Outer-document rules on the host win. */
+:root,
+sp-theme {
+  /* Adobe Clean is proprietary; ship Source Sans 3 / Source Code Pro (see the @fontsource
+     imports in each app entry) with an open fallback stack matching the Spectrum look. */
+  --spectrum-sans-font-family-stack: 'Source Sans 3', 'Source Sans Pro', system-ui, -apple-system, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  --spectrum-code-font-family-stack: 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* Interaction rhythm shared by all hand-rolled controls (Spectrum components bring their own). */
+  --gc-radius: 6px;
+  --gc-transition: 130ms ease-out;
+}

--- a/ui.tests/specs/console.spec.ts
+++ b/ui.tests/specs/console.spec.ts
@@ -20,7 +20,7 @@ test.describe('console', () => {
     const dock = page.locator('.gc-dock');
     await expect(dock.locator('.gc-dock-tab.is-active')).toHaveText('Log', { timeout: 30_000 });
     await expect(dock.locator('.gc-dock-pre')).toContainText('hello from playwright');
-    await expect(dock.locator('sp-badge')).toBeVisible();
+    await expect(dock.locator('.gc-dock-time')).toBeVisible();
   });
 
   test('shows result for returned values', async ({ page }) => {

--- a/ui.tests/specs/helpers.ts
+++ b/ui.tests/specs/helpers.ts
@@ -35,8 +35,8 @@ export async function runScript(page: Page, script: string): Promise<void> {
 
 /** Open the app-bar File menu and click the given item. */
 export async function clickMenuItem(page: Page, item: string): Promise<void> {
-  await page.locator('.gc-overflow sp-action-button').click();
-  await page.locator('.gc-overflow-menu button', { hasText: item }).click();
+  await page.getByRole('button', { name: 'File actions' }).click();
+  await page.getByRole('menuitem', { name: item }).click();
 }
 
 /** Open an activity-rail drawer by its title. */

--- a/ui.tests/specs/scripts.spec.ts
+++ b/ui.tests/specs/scripts.spec.ts
@@ -38,4 +38,32 @@ test.describe.serial('script save and open', () => {
     await expectToast(page, 'Script loaded successfully.');
     expect(await getScriptContent(page)).toContain('playwright save test');
   });
+
+  test('saves a script into a subfolder and opens it back', async ({ page }) => {
+    await openModernUi(page);
+
+    await setScriptContent(page, SCRIPT_CONTENT);
+    await clickMenuItem(page, 'Save…');
+
+    const dialog = page.locator('gc-save-dialog sp-dialog-wrapper');
+    await expect(dialog).toBeVisible();
+
+    // a name with folder segments creates the folders below the scripts root
+    await dialog.locator('sp-textfield').click();
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.type(`pw-folder/${SCRIPT_NAME}-nested`);
+    await dialog.getByRole('button', { name: 'Save' }).click();
+
+    await expectToast(page, 'Script saved successfully.');
+
+    // the folder shows up in the script browser and the script opens from it
+    await clickMenuItem(page, 'Open…');
+    const openDialog = page.locator('gc-script-browser-dialog sp-dialog-wrapper');
+    await expect(openDialog).toBeVisible();
+    await openDialog.locator('.gc-browser-item', { hasText: 'pw-folder' }).click();
+    await openDialog.locator('.gc-browser-item', { hasText: `${SCRIPT_NAME}-nested.groovy` }).click();
+
+    await expectToast(page, 'Script loaded successfully.');
+    expect(await getScriptContent(page)).toContain('playwright save test');
+  });
 });

--- a/ui.tests/specs/streaming.spec.ts
+++ b/ui.tests/specs/streaming.spec.ts
@@ -11,7 +11,7 @@ test.describe('streaming output', () => {
     const dock = page.locator('.gc-dock');
 
     // partial output appears while the script is still running
-    await expect(dock.locator('sp-badge', { hasText: 'live' })).toBeVisible({ timeout: 10_000 });
+    await expect(dock.locator('.gc-dock-live', { hasText: 'Live' })).toBeVisible({ timeout: 10_000 });
     await expect(dock.locator('.gc-dock-pre')).toContainText('stream 0', { timeout: 10_000 });
     await expect(page.locator('.gc-status-bar')).toContainText('Running');
 


### PR DESCRIPTION
## What

A full design-review-driven polish pass over the three modern UIs (console, reports, migration), first-class AEM shell integration, and folder support for saving scripts.

### UI polish (all three apps, light + dark)

- **Monaco follows the color scheme**: custom `gc-light`/`gc-dark` editor themes on the Spectrum surface scale replace the hard-pinned `vs-dark` (a dark editor slab in a light shell was the biggest visual break). The reports editor stays in sync via a window event so the lazy Monaco chunk isn't loaded eagerly.
- **Spectrum controls everywhere**: the `File` menu is a real `sp-action-menu` (label-only), text glyphs (`✕ ↻ ▸ ⏱`) and emoji folder icons are replaced with Spectrum workflow icons, exception badges show the class simple name, and the run time is quiet monospace text.
- **Drawer behavior**: slide-in animation (respects `prefers-reduced-motion`), opens below the app bar, the activity rail stays clickable for direct panel switching, deterministic panel order.
- **Escape closes the Save/Open dialogs** — Spectrum dialogs rendered inline (outside the Overlay system) never handled it.
- **Shared design tokens** (`tokens.css` via the `@console` alias) replace the triplicated `:root` blocks. The font override now also targets `sp-theme`, whose `:host` declaration silently shadowed the `:root` override — the custom font stack never applied before.
- **Bundled fonts**: Source Sans 3 + Source Code Pro (`@fontsource`, OFL), self-hosted per app; Monaco uses the code font with a `remeasureFonts()` once webfonts land.
- **Reports path browser**: Spectrum chevron twisties with rotate transition, double-click-to-confirm like Granite pickers.
- `prefers-color-scheme` is the default when no theme preference is stored; standalone extension app bars show a "Groovy Console /" brand context.

### AEM shell integration

- New `<gc-aem-nav>`: a Coral-shell-style global navigation strip (48px, `#1e1e1e`, Adobe logo + "Adobe Experience Manager") rendered **only on AEM** above the app bar of the console and both standalone extension UIs. Clicking it returns to `/aem/start.html`, so the console behaves like any other Tools page. Zero Granite/Coral dependency; plain Sling renders exactly as before.
- The extension page servlets detect AEM by **service name** (`PageManagerFactory` via BundleContext), so their bundles need no AEM API imports and still resolve on Sling.
- **Tools menu**: Reports moves into **Tools > General** (next to the console entry, with a rendering `graphBarVertical` icon — `documentChart` was not a valid Coral icon name), Migrations moves into **Tools > Deployment** (next to Distribution/Packages). The custom "Groovy Console" Tools group is removed; the nav overlays now use fine-grained package filters (same pattern as `ui.apps.aem`) so they never touch other products' entries.

### Folder-aware script saving

- `saveScript` accepts folder segments in the file name and creates intermediate `sling:Folder`s below the scripts root. Previously `migration/test` produced a file literally named `migration%2Ftest.groovy`; it now saves `test.groovy` into the `migration` folder. `.`/`..` segments are rejected.
- The Save dialog gains the Open dialog's folder navigation (breadcrumbs + folder list), shows the exact target path, prefills names from existing files for overwrite, and remembers the last used folder.

## Verification

- Unit tests: new `saveScriptIntoSubfolder` + `saveScriptRejectsPathTraversal` (13/13 bundle tests green).
- Playwright e2e: specs updated for the new markup, plus a new save-into-subfolder round-trip test — **32/32 passing**.
- Manually verified end-to-end on a plain Sling launcher instance and on an AEM SDK author (2026.2): all drawers/dialogs light+dark, AEM strip + Tools entries, folder saves landing at the right JCR paths, browser consoles clean.
- Full reactor build green including the aemanalyser.