### PR TITLE
Reports: prefill run-form parameters from the URL, with optional autorun

### DIFF
--- a/extensions/reports/README.md
+++ b/extensions/reports/README.md
@@ -252,6 +252,24 @@ build that shares console infrastructure (API client, the Monaco/Groovy editor s
   view with the parameter form, paginated result table, exports and execution history; and an editor view (Monaco
   Groovy editor + parameters) for users with write access. The page shell is served by a servlet in the reports
   bundle, so it exists only when the extension is installed.
+
+  **Deep links & prefilled parameters.** The run view accepts a query string on its route hash so a report can be
+  opened with its form already filled in — and, optionally, run automatically:
+
+  ```
+  /apps/groovyconsole/reports.html#/report/<name>?<param>=<value>&<param>=<value>[&autorun=true]
+  ```
+
+  Each query key that matches a parameter `name` prefills that field (overriding the parameter's default);
+  unknown keys are ignored. Repeating a key (`?tag=a&tag=b`) seeds a `multiple` parameter with several values;
+  for a scalar parameter the last occurrence wins. The reserved `autorun` key requests immediate execution once
+  the form is prefilled (`autorun`, `autorun=1` or `autorun=true` enable it; `autorun=0`/`autorun=false` disable
+  it) — it is optional and off by default. If a required parameter is left unsatisfied, autorun is skipped and the
+  field is flagged instead. Values must be URL-encoded (`%2F` for `/` in a path). Example:
+
+  ```
+  #/report/expired-pages?path=%2Fcontent%2Fmysite&status=expired&tag=marketing&tag=news&autorun=true
+  ```
 - **Developer panel** — a Reports drawer in the modern console's left rail, contributed through the
   `ConsoleUiExtensionProvider` mechanism. The console dynamically imports the panel module the provider announces;
   without the extension installed the console carries no reports code paths at all.

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-app.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-app.ts
@@ -4,7 +4,13 @@ import { config } from '@console/config';
 import { persistence } from '@console/state/local-storage';
 import '@console/components/gc-aem-nav';
 
-type View = { view: 'list' } | { view: 'run'; name: string } | { view: 'edit'; name: string | null };
+type View =
+  | { view: 'list' }
+  | { view: 'run'; name: string; prefill: Record<string, string[]>; autorun: boolean }
+  | { view: 'edit'; name: string | null };
+
+/** Query-string key (in the run route hash) that requests immediate execution once the form is prefilled. */
+const AUTORUN_KEY = 'autorun';
 
 interface Toast {
   message: string;
@@ -104,7 +110,11 @@ export class GcrApp extends LitElement {
   private renderView() {
     switch (this.route.view) {
       case 'run':
-        return html`<gcr-report-run .name=${this.route.name}></gcr-report-run>`;
+        return html`<gcr-report-run
+          .name=${this.route.name}
+          .prefill=${this.route.prefill}
+          .autorun=${this.route.autorun}
+        ></gcr-report-run>`;
       case 'edit':
         return html`<gcr-report-editor .name=${this.route.name}></gcr-report-editor>`;
       default:
@@ -114,7 +124,11 @@ export class GcrApp extends LitElement {
 }
 
 function parseHash(hash: string): View {
-  const path = hash.replace(/^#\/?/, '');
+  const raw = hash.replace(/^#\/?/, '');
+  // split off a "?a=b&c=d" query string so it doesn't leak into the path segments
+  const queryIndex = raw.indexOf('?');
+  const path = queryIndex >= 0 ? raw.slice(0, queryIndex) : raw;
+  const query = queryIndex >= 0 ? raw.slice(queryIndex + 1) : '';
   const segments = path.split('/').filter(Boolean);
 
   if (segments[0] === 'new') {
@@ -128,9 +142,35 @@ function parseHash(hash: string): View {
     } catch {
       name = segments[1];
     }
-    return segments[2] === 'edit' ? { view: 'edit', name } : { view: 'run', name };
+    if (segments[2] === 'edit') {
+      return { view: 'edit', name };
+    }
+    const { prefill, autorun } = parseRunQuery(query);
+    return { view: 'run', name, prefill, autorun };
   }
   return { view: 'list' };
+}
+
+/**
+ * Parse the run route's query string into parameter prefills and the autorun flag. Any key other than the
+ * reserved {@link AUTORUN_KEY} is treated as a parameter value to prefill; unknown keys are simply ignored by
+ * the run view. A key may repeat (`?tag=a&tag=b`) to seed a `multiple` parameter with several values; each key's
+ * occurrences are collected in order. `autorun` (or `autorun=1`/`true`) requests execution on load;
+ * `autorun=0`/`false` disables it.
+ */
+function parseRunQuery(query: string): { prefill: Record<string, string[]>; autorun: boolean } {
+  const prefill: Record<string, string[]> = {};
+  let autorun = false;
+  if (query) {
+    for (const [key, value] of new URLSearchParams(query)) {
+      if (key === AUTORUN_KEY) {
+        autorun = value !== 'false' && value !== '0';
+      } else {
+        (prefill[key] ??= []).push(value);
+      }
+    }
+  }
+  return { prefill, autorun };
 }
 
 /** Helper for child components to surface a toast on the app root. */

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-report-run.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-report-run.ts
@@ -42,6 +42,14 @@ const POLL_MAX_MS = 30 * 60 * 1000;
 @customElement('gcr-report-run')
 export class GcrReportRun extends LitElement {
   @property() name = '';
+  /** Parameter values parsed from the URL, prefilled over each parameter's default when the report loads.
+   *  Each key holds every occurrence of that query parameter, so a `multiple` field can be seeded with a list. */
+  @property({ attribute: false }) prefill: Record<string, string[]> = {};
+  /** When true, the report is executed automatically once loaded and prefilled (if required params are satisfied). */
+  @property({ type: Boolean }) autorun = false;
+
+  /** Set when a load was started for an autorun request, so run() fires exactly once after that load finishes. */
+  private autorunPending = false;
 
   @state() private definition: ReportDefinition | null = null;
   @state() private loaded = false;
@@ -95,6 +103,7 @@ export class GcrReportRun extends LitElement {
 
   protected willUpdate(changed: Map<string, unknown>): void {
     if (changed.has('name') && this.name) {
+      this.autorunPending = this.autorun;
       void this.load();
     }
   }
@@ -119,8 +128,14 @@ export class GcrReportRun extends LitElement {
 
       const defaults: Record<string, ReportParameterValue> = {};
       for (const parameter of definition.parameters) {
+        // a URL prefill for a known parameter overrides its default; for a scalar field the last value wins
+        const prefilled = this.prefill[parameter.name];
         const fallback = parameter.defaultValue ?? '';
-        defaults[parameter.name] = parameter.multiple ? (fallback ? [fallback] : []) : fallback;
+        if (parameter.multiple) {
+          defaults[parameter.name] = prefilled?.length ? prefilled : fallback ? [fallback] : [];
+        } else {
+          defaults[parameter.name] = prefilled?.length ? prefilled[prefilled.length - 1] : fallback;
+        }
       }
       this.values = defaults;
       this.dynamicOptions = {};
@@ -141,6 +156,10 @@ export class GcrReportRun extends LitElement {
     } finally {
       if (!this.stale(token)) {
         this.loaded = true;
+        if (this.autorunPending && !this.error) {
+          this.autorunPending = false;
+          void this.run();
+        }
       }
     }
   }

--- a/ui.tests/specs/reports.spec.ts
+++ b/ui.tests/specs/reports.spec.ts
@@ -33,6 +33,41 @@ test.describe('reports', () => {
     await expect(page.locator('.gcr-result-actions')).toContainText('Download CSV');
   });
 
+  test('prefills a parameter from the URL, overriding its default', async ({ page }) => {
+    // the sample report's PATH parameter defaults to /content; a URL prefill must win over that default
+    await page.goto(`${REPORTS_URL}#/report/sample-content-listing?path=${encodeURIComponent('/apps')}`);
+
+    await expect(page.getByRole('heading', { name: SAMPLE_TITLE })).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator('.gcr-path-input')).toHaveValue('/apps');
+
+    // prefill alone must not execute the report — no result table until the user runs it
+    await expect(page.locator('table.gcr-table')).toHaveCount(0);
+  });
+
+  test('autoruns the report when the URL requests it', async ({ page }) => {
+    // autorun=true executes the prefilled report on load, without the user clicking "Run report"
+    await page.goto(
+      `${REPORTS_URL}#/report/sample-content-listing?path=${encodeURIComponent('/content')}&autorun=true`,
+    );
+
+    const table = page.locator('table.gcr-table');
+    await expect(table).toBeVisible({ timeout: 30_000 });
+    await expect(table.locator('tbody tr').first()).toBeVisible();
+  });
+
+  test('seeds a multi-value parameter from repeated URL keys', async ({ page }) => {
+    // sample-advanced-parameters echoes its submitted params; "names" is a multiple STRING parameter.
+    // Repeating the key must submit both values as a list, which the echo report joins with ", ".
+    await page.goto(
+      `${REPORTS_URL}#/report/sample-advanced-parameters?names=alpha&names=beta&autorun=true`,
+    );
+
+    const table = page.locator('table.gcr-table');
+    await expect(table).toBeVisible({ timeout: 30_000 });
+    const namesRow = table.locator('tbody tr', { hasText: 'names' }).first();
+    await expect(namesRow).toContainText('alpha, beta');
+  });
+
   test('registers a Reports panel in the modern console', async ({ page }) => {
     await page.goto(MODERN_URL);
 


### PR DESCRIPTION
## What

Lets a report be opened with its run form already filled in — and, optionally, executed automatically — via a query string on the run route hash:

```
/apps/groovyconsole/reports.html#/report/<name>?<param>=<value>[&<param>=<value>][&autorun=true]
```

This makes reports shareable/bookmarkable as ready-to-run links (e.g. from a dashboard, an email, or another tool).

## Behaviour

- Each query key matching a parameter `name` prefills that field, **overriding the parameter's default**. Unknown keys are ignored.
- **Multi-value**: repeating a key (`?tag=a&tag=b`) seeds a `multiple` parameter with the full list; a scalar parameter takes the **last** occurrence.
- **`autorun`** (reserved key): `autorun` / `autorun=1` / `autorun=true` runs the report once the form is prefilled. It is **optional and off by default**; `autorun=0` / `autorun=false` disable it. If a required parameter is left unsatisfied, autorun is skipped and the field is flagged instead.
- Values must be URL-encoded (`%2F` for `/` in a path).

Example:

```
#/report/expired-pages?path=%2Fcontent%2Fmysite&tag=marketing&tag=news&autorun=true
```

## Changes

- `gcr-app.ts` — `parseRunQuery` splits the query off the route hash and collects repeated keys into arrays (`prefill: Record<string, string[]>`).
- `gcr-report-run.ts` — new `prefill`/`autorun` properties; the defaults merge respects `parameter.multiple` (list vs. scalar-last-wins); one-shot autorun after load.
- `README.md` — documents the deep-link format.

## Testing

- New Playwright specs in `ui.tests/specs/reports.spec.ts`: prefill (overrides default, no execution), autorun, and multi-value seeding from repeated keys.
- Full local run green: `mvn clean install -Pit,ui-tests` — all IT suites pass (incl. `GroovyConsoleReportsIT` 24/24, `GroovyConsoleReportsAclIT` 15/15) and Playwright **35 passed**.

Built on top of #91 (multi-value / tag / dynamic parameter types).