### PR TITLE
Make deployment migrations cloud-compatible (AEMaaCS + on-prem)

### DIFF
--- a/extensions/migration/README.md
+++ b/extensions/migration/README.md
@@ -3,10 +3,14 @@
 Deployment migration extension for the AEM Groovy Console, replacing the deprecated
 [AEM Easy Content Upgrade (AECU)](https://github.com/valtech/aem-easy-content-upgrade) project.
 
-Groovy migration scripts are deployed via content package below `/conf/groovyconsole/scripts/migration` and
-executed with **checksum-based run-once semantics**: a script runs when it is new, its content changed or its
-last execution was not successful. Scripts execute in deterministic alphanumeric path order with fail-fast
-behavior, and a light run history is kept below `/var/groovyconsole/migration`.
+Groovy migration scripts are deployed via content package below an immutable `/apps/groovyconsole-migration-scripts`
+path and/or the mutable `/conf/groovyconsole/scripts/migration` path, and executed with **checksum-based run-once
+semantics**: a script runs when it is new, its content changed or its last execution was not successful. Scripts
+execute in deterministic alphanumeric path order with fail-fast behavior, and a light run history is kept below
+`/var/groovyconsole/migration`.
+
+Works on **AEM 6.5 on-premises, AMS and AEM as a Cloud Service** as well as plain Apache Sling — see
+[Cloud vs on-premises](#cloud-vs-on-premises) for how automatic execution differs per environment.
 
 ## Installation (opt-in)
 
@@ -16,13 +20,23 @@ service user (`aem-groovy-console-migration-service`) and OSGi configuration.
 
 ## Writing migration scripts
 
-Deploy `.groovy` files (typically via a content package) below `/conf/groovyconsole/scripts/migration`.
-Scripts are regular Groovy Console scripts with all console bindings (`resourceResolver`, `session`, etc.)
-available, executed by the extension's service user. They are discovered recursively and executed in
-alphanumeric path order, so a numeric prefix convention keeps the order explicit:
+Deploy `.groovy` files (typically via a content package) below one of the configured scripts base paths. Two
+paths are searched by default (both optional, searched in order, missing paths skipped):
+
+- **`/apps/groovyconsole-migration-scripts`** — *immutable*, recommended on AEM as a Cloud Service. Scripts
+  ship inside the code image (present on both author and publish, read-only at runtime) and are picked up
+  automatically by the [cloud startup hook](#cloud-vs-on-premises). Deploy them here from your project's own
+  content package.
+- **`/conf/groovyconsole/scripts/migration`** — *mutable*, suited to authored or ad-hoc scripts.
+
+Configure a different set (or a single path) via `scriptsBasePaths` on the `MigrationService` OSGi
+configuration. Scripts are regular Groovy Console scripts with all console bindings (`resourceResolver`,
+`session`, etc.) available, executed by the extension's service user. They are discovered recursively and
+executed in alphanumeric path order across all base paths (`/apps` sorts before `/conf`), so a numeric prefix
+convention keeps the order explicit:
 
 ```
-/conf/groovyconsole/scripts/migration/
+/apps/groovyconsole-migration-scripts/
     2025/
         001-activate-new-templates.groovy
         002-cleanup-legacy-paths.author.groovy
@@ -46,13 +60,19 @@ script already committed itself (e.g. an explicit `session.save()` halfway) are 
 
 ## Triggering
 
+- **Startup hook** (automatic, cloud by default): on bundle activation the extension detects an AEM as a Cloud
+  Service instance (composite node store) and enqueues a run of the pending scripts once the instance is ready.
+  Controlled by `autoRunOnStartup` (`cloudOnly` default / `always` / `never`) on the `MigrationStartupHook` OSGi
+  configuration — see [Cloud vs on-premises](#cloud-vs-on-premises).
 - **HTTP API** (CI/CD): `POST /bin/groovyconsole/migration` — synchronous by default, `async=true` returns a
   `runId` for polling via `GET ?runId=...`, `dryRun=true` previews without executing. `path=...` scopes the run
   to a single script or folder instead of the configured scripts base path; `data=...` (JSON or plain string) is
   made available to every script in the run as the `data` binding variable. `GET ?registry=true` / `?pending=true`
   expose the per-script state. Returns `409 Conflict` while a run is in progress.
 - **Resource listener** (opt-in, disabled by default): enqueues a run automatically when migration scripts
-  are added/changed, debounced. Enable via the `MigrationScriptListener` OSGi configuration.
+  are added/changed under either default base path, debounced. Enable via the `MigrationScriptListener` OSGi
+  configuration. Note that immutable `/apps` changes on AEMaaCS are applied by a container swap and do not fire
+  resource events — the startup hook covers auto-run there instead.
 - **JMX** (e.g. JConsole, or a scripted JMX client): `be.orbinson.aem.groovyconsole:type=Migration` exposes
   `run()`, `run(path)` and `run(path, data)` (synchronous, same semantics as the HTTP API above), plus
   `isRunning()`, `getPendingScripts()` and `getRuns(count)`. Mirrors `AecuServiceMBean`, adapted to this
@@ -107,14 +127,22 @@ Two Apache Felix Health Checks are registered under the `migration` tag (mirrori
 
 `be.orbinson.aem.groovy.console.migration.impl.DefaultMigrationService`:
 
-| Property                 | Default                                | Description                                                        |
-|--------------------------|----------------------------------------|--------------------------------------------------------------------|
-| `scriptsBasePath`        | `/conf/groovyconsole/scripts/migration`| JCR path containing the migration scripts                          |
-| `allowedMigrationGroups` | *(empty)*                              | Groups allowed to trigger runs (admin always allowed)              |
-| `staleLockMillis`        | `1800000`                              | Time after which an in-progress run lock is considered stale       |
-| `maxRunHistory`          | `50`                                   | Number of runs kept in the history; older runs are pruned          |
-| `maxOutputChars`         | `4096`                                 | Script output characters stored per result (full output in audit)  |
-| `runModeFilterEnabled`   | `true`                                 | Honor `author`/`publish` file name tokens                          |
+| Property                 | Default                                     | Description                                                        |
+|--------------------------|---------------------------------------------|--------------------------------------------------------------------|
+| `scriptsBasePaths`       | `/apps/groovyconsole-migration-scripts`, `/conf/groovyconsole/scripts/migration` | JCR paths containing the migration scripts, searched in order; missing paths skipped |
+| `allowedMigrationGroups` | *(empty)*                                   | Groups allowed to trigger runs (admin always allowed)              |
+| `staleLockMillis`        | `1800000`                                   | Time after which an in-progress run lock is considered stale       |
+| `maxRunHistory`          | `50`                                        | Number of runs kept in the history; older runs are pruned          |
+| `maxOutputChars`         | `4096`                                      | Script output characters stored per result (full output in audit)  |
+| `runModeFilterEnabled`   | `true`                                      | Honor `author`/`publish` file name tokens                          |
+
+`be.orbinson.aem.groovy.console.migration.impl.MigrationStartupHook`:
+
+| Property                | Default     | Description                                                                                  |
+|-------------------------|-------------|----------------------------------------------------------------------------------------------|
+| `autoRunOnStartup`      | `cloudOnly` | When to auto-run on activation: `cloudOnly` (AEMaaCS composite node store), `always`, `never` |
+| `bootDelayMillis`       | `10000`     | Delay after activation before the startup run, letting the instance settle                   |
+| `readinessTimeoutMillis`| `300000`    | Max time to wait for the repository/service user to become available                         |
 
 `be.orbinson.aem.groovy.console.migration.impl.MigrationScriptListener`:
 
@@ -123,8 +151,29 @@ Two Apache Felix Health Checks are registered under the `migration` tag (mirrori
 | `enabled`        | `false` | Automatically enqueue a run when migration scripts change         |
 | `debounceMillis` | `3000`  | Coalesce bursts of change events into a single run                |
 
-When overriding `scriptsBasePath`, the listener's `resource.paths` component property must be overridden
+When overriding `scriptsBasePaths`, the listener's `resource.paths` component property must be overridden
 accordingly via OSGi configuration.
+
+## Cloud vs on-premises
+
+Migrations can run automatically on deployment in every supported environment; the available trigger differs,
+so pick the row that matches yours:
+
+| Environment                       | Recommended scripts path                | How migrations run on deploy                                                                  |
+|-----------------------------------|-----------------------------------------|-----------------------------------------------------------------------------------------------|
+| **AEM as a Cloud Service**        | `/apps/groovyconsole-migration-scripts` | **Startup hook** enqueues pending scripts automatically when the container starts. No pipeline step required. |
+| **AEM 6.5 on-premises / AMS**     | either path (via content package)       | Enable the **resource listener** to run pending scripts when the package installs, or trigger the **HTTP API** / **JMX** from your deployment tooling. The startup hook stays inactive by default (`cloudOnly`). |
+| **Apache Sling / local dev**      | either path                             | HTTP API, JMX, resource listener, or set `autoRunOnStartup=always` to run on every startup.    |
+
+Scripts under `/apps` ship inside the immutable code image (present on author and publish, read-only at
+runtime); scripts under `/conf` are mutable content, deployed to author only. Execution state always lives
+under mutable `/var/groovyconsole/migration`. Set `autoRunOnStartup=always` to also auto-run on premises, or
+`never` to rely solely on the listener / HTTP API / JMX.
+
+On a horizontally scaled publish tier each pod runs the migrations against its own repository (each pod's
+`/var` state is independent); the per-instance run lock in `/var/groovyconsole/migration` prevents concurrent
+runs within an instance. Use the [health checks](#health-checks) (tag `migration`) to gate a cloud pipeline on
+migration success.
 
 ## Persistence model
 
@@ -139,4 +188,6 @@ Follows the reports extension methodology: `api` (exported interfaces), `bundle`
 `ui.frontend` (Lit + Spectrum Web Components UI built with Vite into `ui.apps` under the migration-owned
 `/apps/groovyconsole-migration/spa` path, sharing console infrastructure via the `@console` alias), `ui.apps`
 (SPA assets + AEM Tools navigation overlay), `ui.config` (service user, repoinit, ordered job queue),
-`ui.content` (the `/conf/groovyconsole/scripts/migration` folder) and `all` (the container package).
+`ui.content` (the mutable `/conf/groovyconsole/scripts/migration` folder) and `all` (the container package).
+Migration scripts destined for the immutable `/apps/groovyconsole-migration-scripts` path are deployed by the
+customer's own content package, not by this extension.

--- a/extensions/migration/api/src/main/groovy/be/orbinson/aem/groovy/console/migration/MigrationConstants.groovy
+++ b/extensions/migration/api/src/main/groovy/be/orbinson/aem/groovy/console/migration/MigrationConstants.groovy
@@ -8,9 +8,24 @@ class MigrationConstants {
 
     public static final String PATH_MIGRATION_RUNS = "$PATH_MIGRATION_ROOT/runs"
 
+    /** Immutable scripts path: ships with the code image (reaches publish, tamper-proof) -- preferred on AEMaaCS. */
+    public static final String DEFAULT_SCRIPTS_BASE_PATH_APPS = "/apps/groovyconsole-migration-scripts"
+
+    /** Mutable scripts path: authored/ad-hoc scripts, deployed as mutable content (author only on AEMaaCS). */
     public static final String DEFAULT_SCRIPTS_BASE_PATH = "/conf/groovyconsole/scripts/migration"
 
+    /**
+     * Default scripts base paths, searched in order. Missing paths are skipped, so a deployment can use the
+     * immutable {@code /apps} path, the mutable {@code /conf} path, or both.
+     */
+    public static final List<String> DEFAULT_SCRIPTS_BASE_PATHS =
+            [DEFAULT_SCRIPTS_BASE_PATH_APPS, DEFAULT_SCRIPTS_BASE_PATH].asImmutable()
+
     public static final String MIGRATION_JOB_TOPIC = "groovyconsole/migration"
+
+    // startup / trigger
+
+    public static final String TRIGGER_STARTUP = "STARTUP"
 
     // request parameters
 

--- a/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/DefaultMigrationService.groovy
+++ b/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/DefaultMigrationService.groovy
@@ -60,7 +60,7 @@ class DefaultMigrationService implements MigrationService {
     @Reference
     private SlingSettingsService slingSettingsService
 
-    private String scriptsBasePath
+    private List<String> scriptsBasePaths
 
     private Set<String> allowedMigrationGroups
 
@@ -75,7 +75,7 @@ class DefaultMigrationService implements MigrationService {
     @Activate
     @Synchronized
     void activate(MigrationServiceProperties properties) {
-        scriptsBasePath = properties.scriptsBasePath()
+        scriptsBasePaths = ((properties.scriptsBasePaths() ?: []).findAll() ?: DEFAULT_SCRIPTS_BASE_PATHS) as List
         allowedMigrationGroups = (properties.allowedMigrationGroups() ?: []).findAll() as Set
         staleLockMillis = properties.staleLockMillis()
         maxRunHistory = properties.maxRunHistory()
@@ -96,8 +96,8 @@ class DefaultMigrationService implements MigrationService {
                     isPendingScript(resourceResolver, script)
                 }
 
-                LOG.info("found {} pending migration script(s) below path : {}", pendingScripts.size(),
-                        options.path ?: scriptsBasePath)
+                LOG.info("found {} pending migration script(s) below path(s) : {}", pendingScripts.size(),
+                        options.path ?: scriptsBasePaths.join(", "))
 
                 def results
                 def status
@@ -287,15 +287,19 @@ class DefaultMigrationService implements MigrationService {
     private List<Map> findScripts(ResourceResolver resourceResolver, String overridePath = null) {
         def scripts = []
 
-        def rootPath = overridePath ?: scriptsBasePath
-        def rootResource = resourceResolver.getResource(rootPath)
+        def rootPaths = overridePath ? [overridePath] : scriptsBasePaths
 
-        if (rootResource) {
-            collectScripts(rootResource, scripts)
-        } else {
-            LOG.debug("migration scripts path not found : {}", rootPath)
+        rootPaths.each { rootPath ->
+            def rootResource = resourceResolver.getResource(rootPath)
+
+            if (rootResource) {
+                collectScripts(rootResource, scripts)
+            } else {
+                LOG.debug("migration scripts path not found : {}", rootPath)
+            }
         }
 
+        // deterministic alphanumeric path order across all base paths (/apps sorts before /conf)
         scripts.sort { script -> script.path }
     }
 

--- a/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/MigrationScriptListener.groovy
+++ b/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/MigrationScriptListener.groovy
@@ -23,10 +23,14 @@ import static be.orbinson.aem.groovy.console.migration.MigrationConstants.TRIGGE
  * Optionally enqueues a migration run when migration scripts are added or changed, e.g. by a content package
  * installation.  Bursts of change events are debounced into a single asynchronous run.  Disabled by default.
  *
- * <p>Note: when overriding the migration scripts base path, the <code>resource.paths</code> property of this
- * component must be overridden accordingly via OSGi configuration.</p>
+ * <p>Watches both the immutable <code>/apps</code> and mutable <code>/conf</code> default script paths.  On AEM as a
+ * Cloud Service immutable <code>/apps</code> changes are applied by a container swap rather than at runtime, so they
+ * do not fire resource events -- the {@link MigrationStartupHook} covers auto-run there instead.  When overriding the
+ * migration scripts base paths, the <code>resource.paths</code> property of this component must be overridden
+ * accordingly via OSGi configuration.</p>
  */
 @Component(property = [
+        "resource.paths=glob:/apps/groovyconsole-migration-scripts/**",
         "resource.paths=glob:/conf/groovyconsole/scripts/migration/**",
         "resource.change.types=ADDED",
         "resource.change.types=CHANGED"

--- a/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/MigrationStartupHook.groovy
+++ b/extensions/migration/bundle/src/main/groovy/be/orbinson/aem/groovy/console/migration/impl/MigrationStartupHook.groovy
@@ -1,0 +1,183 @@
+package be.orbinson.aem.groovy.console.migration.impl
+
+import be.orbinson.aem.groovy.console.migration.MigrationRunOptions
+import be.orbinson.aem.groovy.console.migration.MigrationService
+import groovy.util.logging.Slf4j
+import org.apache.sling.api.resource.ResourceResolver
+import org.apache.sling.api.resource.ResourceResolverFactory
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Deactivate
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.metatype.annotations.Designate
+
+import javax.jcr.Session
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
+
+import static be.orbinson.aem.groovy.console.migration.MigrationConstants.TRIGGER_STARTUP
+
+/**
+ * Enqueues a migration run after the bundle activates.  With the default {@code cloudOnly} mode it runs only on a
+ * composite node store (AEM as a Cloud Service), where each deployment restarts the container; {@code always} runs on
+ * every startup, {@code never} disables the hook.
+ */
+@Component(immediate = true)
+@Designate(ocd = MigrationStartupHookProperties)
+@Slf4j("LOG")
+class MigrationStartupHook {
+
+    static enum AutoRunMode {
+        NEVER, CLOUD_ONLY, ALWAYS
+
+        static AutoRunMode from(String value) {
+            switch (value?.toLowerCase()) {
+                case "always": return ALWAYS
+                case "never": return NEVER
+                default: return CLOUD_ONLY
+            }
+        }
+    }
+
+    private static final long READINESS_POLL_MILLIS = 2000
+
+    @Reference
+    private MigrationService migrationService
+
+    @Reference
+    private ResourceResolverFactory resourceResolverFactory
+
+    private AutoRunMode autoRunMode
+
+    private long bootDelayMillis
+
+    private long readinessTimeoutMillis
+
+    private ScheduledExecutorService executor
+
+    @Activate
+    void activate(MigrationStartupHookProperties properties) {
+        autoRunMode = AutoRunMode.from(properties.autoRunOnStartup())
+        bootDelayMillis = properties.bootDelayMillis()
+        readinessTimeoutMillis = properties.readinessTimeoutMillis()
+
+        if (autoRunMode == AutoRunMode.NEVER) {
+            LOG.debug("migration startup hook disabled")
+
+            return
+        }
+
+        executor = Executors.newSingleThreadScheduledExecutor({ Runnable runnable ->
+            def thread = new Thread(runnable, "groovyconsole-migration-startup")
+            thread.daemon = true
+            thread
+        } as ThreadFactory)
+
+        LOG.info("scheduling startup migration check (mode : {}) in {} ms", autoRunMode, bootDelayMillis)
+
+        executor.schedule({ triggerStartupRun() } as Runnable, bootDelayMillis, TimeUnit.MILLISECONDS)
+    }
+
+    @Deactivate
+    void deactivate() {
+        executor?.shutdownNow()
+        executor = null
+    }
+
+    // package-visible so tests can exercise it directly without the scheduling delay
+    void triggerStartupRun() {
+        try {
+            if (!awaitReadiness()) {
+                LOG.warn("repository did not become ready within {} ms, skipping startup migration",
+                        readinessTimeoutMillis)
+
+                return
+            }
+
+            def cloud = isCompositeNodeStore()
+
+            LOG.info("startup migration check : autoRunMode={}, composite node store (AEMaaCS)={}", autoRunMode, cloud)
+
+            if (autoRunMode == AutoRunMode.CLOUD_ONLY && !cloud) {
+                LOG.info("skipping startup migration : not a cloud (composite node store) instance")
+
+                return
+            }
+
+            if (migrationService.running) {
+                LOG.info("skipping startup migration : a run is already in progress")
+
+                return
+            }
+
+            def pending = migrationService.pendingScripts
+
+            if (pending.empty) {
+                LOG.info("no pending migration scripts on startup")
+
+                return
+            }
+
+            def runId = migrationService.enqueue(new MigrationRunOptions(trigger: TRIGGER_STARTUP))
+
+            LOG.info("enqueued startup migration run with ID : {} for {} pending script(s)", runId, pending.size())
+        } catch (IllegalStateException e) {
+            LOG.warn("unable to enqueue startup migration run : {}", e.message)
+        } catch (Exception e) {
+            LOG.error("error during startup migration run", e)
+        }
+    }
+
+    private boolean awaitReadiness() {
+        def deadline = System.currentTimeMillis() + readinessTimeoutMillis
+
+        while (true) {
+            try {
+                if (withResourceResolver { ResourceResolver resolver -> resolver.adaptTo(Session) != null }) {
+                    return true
+                }
+            } catch (Exception e) {
+                LOG.debug("repository not ready yet : {}", e.message)
+            }
+
+            if (System.currentTimeMillis() >= deadline) {
+                return false
+            }
+
+            Thread.sleep(READINESS_POLL_MILLIS)
+        }
+    }
+
+    protected boolean isCompositeNodeStore() {
+        withResourceResolver { ResourceResolver resolver -> isCompositeNodeStore(resolver) }
+    }
+
+    // Composite node store (AEMaaCS) detection, as in the AC Tool and ACM: /apps is immutable there, so a session
+    // that has write permission yet cannot add a node under /apps is on cloud. The permission guard avoids
+    // misclassifying a permission-limited session (hasCapability is also false then). See OAK-6563.
+    protected boolean isCompositeNodeStore(ResourceResolver resolver) {
+        def session = resolver.adaptTo(Session)
+
+        if (session == null) {
+            return false
+        }
+
+        try {
+            def appsNode = session.getNode("/apps")
+            def hasPermission = session.hasPermission("/", Session.ACTION_SET_PROPERTY)
+            def hasCapability = session.hasCapability("addNode", appsNode, ["nt:folder"] as Object[])
+
+            hasPermission && !hasCapability
+        } catch (Exception e) {
+            LOG.warn("could not determine composite node store, assuming non-composite : {}", e.message)
+
+            false
+        }
+    }
+
+    private <T> T withResourceResolver(Closure<T> closure) {
+        resourceResolverFactory.getServiceResourceResolver(null).withCloseable(closure)
+    }
+}

--- a/extensions/migration/bundle/src/main/java/be/orbinson/aem/groovy/console/migration/impl/MigrationServiceProperties.java
+++ b/extensions/migration/bundle/src/main/java/be/orbinson/aem/groovy/console/migration/impl/MigrationServiceProperties.java
@@ -6,9 +6,16 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 @ObjectClassDefinition(name = "Groovy Console Migration Service")
 public @interface MigrationServiceProperties {
 
-    @AttributeDefinition(name = "Scripts Base Path",
-        description = "JCR path containing the deployment migration scripts.")
-    String scriptsBasePath() default "/conf/groovyconsole/scripts/migration";
+    @AttributeDefinition(name = "Scripts Base Paths",
+        description = "JCR paths containing the deployment migration scripts, searched in order.  Missing paths are "
+            + "skipped.  The immutable /apps path ships with the code image (reaching publish and surviving on "
+            + "AEMaaCS where /conf is mutable, author-only content); the mutable /conf path suits authored or ad-hoc "
+            + "scripts.",
+        cardinality = 20)
+    String[] scriptsBasePaths() default {
+        "/apps/groovyconsole-migration-scripts",
+        "/conf/groovyconsole/scripts/migration"
+    };
 
     @AttributeDefinition(name = "Migration Allowed Groups",
         description = "List of group names that are authorized to trigger migration runs.  By default, only the 'admin' user has permission to trigger migrations.",

--- a/extensions/migration/bundle/src/main/java/be/orbinson/aem/groovy/console/migration/impl/MigrationStartupHookProperties.java
+++ b/extensions/migration/bundle/src/main/java/be/orbinson/aem/groovy/console/migration/impl/MigrationStartupHookProperties.java
@@ -1,0 +1,34 @@
+package be.orbinson.aem.groovy.console.migration.impl;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Option;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition(name = "Groovy Console Migration Startup Hook",
+    description = "Automatically runs pending migration scripts after a deployment.  On AEM as a Cloud Service there "
+        + "is no manual step or install hook in the standard pipeline, so this hook enqueues a run once the instance "
+        + "is ready.  Cloud instances are detected via the composite node store.")
+public @interface MigrationStartupHookProperties {
+
+    @AttributeDefinition(name = "Auto Run On Startup",
+        description = "When to automatically enqueue a migration run after the bundle activates.  'cloudOnly' runs "
+            + "only on AEM as a Cloud Service (composite node store), avoiding a run on every on-premises restart; "
+            + "'always' runs on every startup (run-once semantics still skip unchanged scripts); 'never' disables the "
+            + "hook so runs are triggered manually via the HTTP API, JMX or the resource listener.",
+        options = {
+            @Option(label = "Cloud only (AEMaaCS)", value = "cloudOnly"),
+            @Option(label = "Always", value = "always"),
+            @Option(label = "Never", value = "never")
+        })
+    String autoRunOnStartup() default "cloudOnly";
+
+    @AttributeDefinition(name = "Boot Delay",
+        description = "Time in milliseconds to wait after bundle activation before attempting the startup run, giving "
+            + "the instance time to settle.")
+    long bootDelayMillis() default 10000;
+
+    @AttributeDefinition(name = "Readiness Timeout",
+        description = "Maximum time in milliseconds to wait for the repository/service user to become available "
+            + "before giving up on the startup run.")
+    long readinessTimeoutMillis() default 300000;
+}

--- a/extensions/migration/bundle/src/test/groovy/be/orbinson/aem/groovy/console/migration/impl/DefaultMigrationServiceTest.groovy
+++ b/extensions/migration/bundle/src/test/groovy/be/orbinson/aem/groovy/console/migration/impl/DefaultMigrationServiceTest.groovy
@@ -398,9 +398,47 @@ class DefaultMigrationServiceTest {
         assertNull(migrationService.getRun(null))
     }
 
+    @Test
+    void discoversScriptsFromBothDefaultBasePathsInPathOrder() {
+        context.build().resource(DEFAULT_SCRIPTS_BASE_PATH_APPS).commit()
+
+        addScriptAt(DEFAULT_SCRIPTS_BASE_PATH_APPS, "001-apps.groovy", "apps script")
+        addScript("001-conf.groovy", "conf script")
+
+        def run = migrationService.run(new MigrationRunOptions())
+
+        assertEquals(MigrationStatus.SUCCESS, run.status)
+        // /apps sorts before /conf, so the immutable script runs first
+        assertEquals(["apps script", "conf script"], executedScripts)
+        assertEquals([
+                "$DEFAULT_SCRIPTS_BASE_PATH_APPS/001-apps.groovy" as String,
+                "$DEFAULT_SCRIPTS_BASE_PATH/001-conf.groovy" as String
+        ], run.results*.scriptPath)
+    }
+
+    @Test
+    void honorsConfiguredSingleBasePath() {
+        migrationService = context.registerInjectActivateService(new DefaultMigrationService(),
+                [scriptsBasePaths: [DEFAULT_SCRIPTS_BASE_PATH_APPS] as String[]])
+
+        context.build().resource(DEFAULT_SCRIPTS_BASE_PATH_APPS).commit()
+
+        addScriptAt(DEFAULT_SCRIPTS_BASE_PATH_APPS, "001-apps.groovy", "apps script")
+        addScript("001-conf.groovy", "conf script")
+
+        migrationService.run(new MigrationRunOptions())
+
+        // only the /apps path is configured, so the /conf script is ignored
+        assertEquals(["apps script"], executedScripts)
+    }
+
     private void addScript(String name, String content) {
+        addScriptAt(DEFAULT_SCRIPTS_BASE_PATH, name, content)
+    }
+
+    private void addScriptAt(String basePath, String name, String content) {
         context.load().binaryFile(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)),
-                "$DEFAULT_SCRIPTS_BASE_PATH/$name")
+                "$basePath/$name")
     }
 
     private void replaceScript(String name, String content) {

--- a/extensions/migration/bundle/src/test/groovy/be/orbinson/aem/groovy/console/migration/impl/MigrationStartupHookTest.groovy
+++ b/extensions/migration/bundle/src/test/groovy/be/orbinson/aem/groovy/console/migration/impl/MigrationStartupHookTest.groovy
@@ -1,0 +1,131 @@
+package be.orbinson.aem.groovy.console.migration.impl
+
+import be.orbinson.aem.groovy.console.migration.MigrationRunOptions
+import be.orbinson.aem.groovy.console.migration.MigrationService
+import org.apache.sling.api.resource.ResourceResolver
+import org.apache.sling.api.resource.ResourceResolverFactory
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+
+import javax.jcr.Node
+import javax.jcr.Session
+
+import static be.orbinson.aem.groovy.console.migration.MigrationConstants.TRIGGER_STARTUP
+import static be.orbinson.aem.groovy.console.migration.impl.MigrationStartupHook.AutoRunMode
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.eq
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.never
+import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
+
+class MigrationStartupHookTest {
+
+    @Test
+    void cloudOnlyEnqueuesOnCompositeNodeStore() {
+        def service = migrationService(false, ["/apps/groovyconsole-migration-scripts/001.groovy"])
+
+        hook(service, resolver(true), AutoRunMode.CLOUD_ONLY).triggerStartupRun()
+
+        def captor = ArgumentCaptor.forClass(MigrationRunOptions)
+        verify(service).enqueue(captor.capture())
+        assertEquals(TRIGGER_STARTUP, captor.value.trigger)
+    }
+
+    @Test
+    void cloudOnlySkipsOnSingleNodeStore() {
+        def service = migrationService(false, ["/x"])
+
+        hook(service, resolver(false), AutoRunMode.CLOUD_ONLY).triggerStartupRun()
+
+        verify(service, never()).enqueue(any())
+    }
+
+    @Test
+    void alwaysEnqueuesOnSingleNodeStore() {
+        def service = migrationService(false, ["/x"])
+
+        hook(service, resolver(false), AutoRunMode.ALWAYS).triggerStartupRun()
+
+        verify(service).enqueue(any())
+    }
+
+    @Test
+    void skipsWhenNoPendingScripts() {
+        def service = migrationService(false, [])
+
+        hook(service, resolver(true), AutoRunMode.ALWAYS).triggerStartupRun()
+
+        verify(service, never()).enqueue(any())
+    }
+
+    @Test
+    void skipsWhenRunAlreadyInProgress() {
+        def service = migrationService(true, ["/x"])
+
+        hook(service, resolver(true), AutoRunMode.ALWAYS).triggerStartupRun()
+
+        verify(service, never()).enqueue(any())
+    }
+
+    @Test
+    void detectsCompositeAndSingleNodeStore() {
+        def hook = new MigrationStartupHook()
+
+        assertTrue(hook.isCompositeNodeStore(resolver(true)))
+        assertFalse(hook.isCompositeNodeStore(resolver(false)))
+    }
+
+    @Test
+    void permissionLimitedSessionIsNotClassifiedAsComposite() {
+        // a session without general write permission also fails hasCapability, but must not be treated as cloud
+        def session = mock(Session)
+        def appsNode = mock(Node)
+
+        when(session.getNode("/apps")).thenReturn(appsNode)
+        when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(false)
+        when(session.hasCapability(eq("addNode"), eq(appsNode), any(Object[]))).thenReturn(false)
+
+        def resolver = mock(ResourceResolver)
+        when(resolver.adaptTo(Session)).thenReturn(session)
+
+        assertFalse(new MigrationStartupHook().isCompositeNodeStore(resolver))
+    }
+
+    private static MigrationService migrationService(boolean running, List<String> pending) {
+        def service = mock(MigrationService)
+        when(service.running).thenReturn(running)
+        when(service.pendingScripts).thenReturn(pending)
+        when(service.enqueue(any())).thenReturn("run-id")
+        service
+    }
+
+    private static MigrationStartupHook hook(MigrationService service, ResourceResolver resolver, AutoRunMode mode) {
+        def factory = mock(ResourceResolverFactory)
+        when(factory.getServiceResourceResolver(null)).thenReturn(resolver)
+
+        def hook = new MigrationStartupHook()
+        hook.@migrationService = service
+        hook.@resourceResolverFactory = factory
+        hook.@autoRunMode = mode
+        hook.@readinessTimeoutMillis = 5000L
+        hook
+    }
+
+    private static ResourceResolver resolver(boolean composite) {
+        def session = mock(Session)
+        def appsNode = mock(Node)
+
+        when(session.getNode("/apps")).thenReturn(appsNode)
+        when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(true)
+        // hasCapability returns false when the operation would fail -> immutable /apps -> composite (cloud) store
+        when(session.hasCapability(eq("addNode"), eq(appsNode), any(Object[]))).thenReturn(!composite)
+
+        def resolver = mock(ResourceResolver)
+        when(resolver.adaptTo(Session)).thenReturn(session)
+        resolver
+    }
+}

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/MigrationIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/MigrationIT.java
@@ -38,6 +38,7 @@ class MigrationIT {
 
     private static final String MIGRATION_ENDPOINT = "/bin/groovyconsole/migration";
     private static final String SCRIPTS_BASE_PATH = "/conf/groovyconsole/scripts/migration";
+    private static final String APPS_SCRIPTS_BASE_PATH = "/apps/groovyconsole-migration-scripts";
 
     private static CloseableHttpClient httpClient;
 
@@ -236,6 +237,28 @@ class MigrationIT {
         }
     }
 
+    @Test
+    @Order(10)
+    void testImmutableAppsPathScriptsAreDiscovered() throws Exception {
+        // scripts under the immutable /apps path are discovered alongside /conf by the default multi-path config
+        createMigrationScriptAt(APPS_SCRIPTS_BASE_PATH, "100-apps-migration.groovy", "println 'migration from apps'");
+
+        try {
+            JsonObject run = postMigration(200);
+
+            assertEquals("SUCCESS", run.get("status").getAsString());
+
+            JsonObject result = findResult(run, "100-apps-migration.groovy");
+            assertNotNull(result, "Expected the /apps script to be discovered and executed");
+            assertEquals("SUCCESS", result.get("status").getAsString());
+            assertEquals(APPS_SCRIPTS_BASE_PATH + "/100-apps-migration.groovy",
+                    result.get("scriptPath").getAsString());
+            assertTrue(result.get("output").getAsString().contains("migration from apps"));
+        } finally {
+            deleteMigrationScriptAt(APPS_SCRIPTS_BASE_PATH, "100-apps-migration.groovy");
+        }
+    }
+
     private static boolean endpointsAvailable() {
         try {
             // probe the console post servlet
@@ -317,6 +340,35 @@ class MigrationIT {
 
         assertEquals("", response.get("exceptionStackTrace").getAsString(),
                 "Could not create migration script " + name);
+    }
+
+    private static void createMigrationScriptAt(String basePath, String name, String content) throws IOException {
+        String encodedContent = Base64.encodeBase64String(content.getBytes(StandardCharsets.UTF_8));
+
+        JsonObject response = executeScript(
+                "import org.apache.jackrabbit.commons.JcrUtils\n" +
+                "def parent = JcrUtils.getOrCreateByPath('" + basePath + "', 'sling:Folder', session)\n" +
+                "if (parent.hasNode('" + name + "')) { parent.getNode('" + name + "').remove() }\n" +
+                "def file = parent.addNode('" + name + "', 'nt:file')\n" +
+                "def resource = file.addNode('jcr:content', 'nt:resource')\n" +
+                "def bytes = '" + encodedContent + "'.decodeBase64()\n" +
+                "resource.setProperty('jcr:data', session.valueFactory.createBinary(new ByteArrayInputStream(bytes)))\n" +
+                "session.save()"
+        );
+
+        assertEquals("", response.get("exceptionStackTrace").getAsString(),
+                "Could not create migration script " + name + " at " + basePath);
+    }
+
+    private static void deleteMigrationScriptAt(String basePath, String name) throws IOException {
+        JsonObject response = executeScript(
+                "def node = session.nodeExists('" + basePath + "/" + name + "') ? " +
+                "session.getNode('" + basePath + "/" + name + "') : null\n" +
+                "if (node) { node.remove(); session.save() }"
+        );
+
+        assertEquals("", response.get("exceptionStackTrace").getAsString(),
+                "Could not delete migration script " + name + " at " + basePath);
     }
 
     private static void deleteMigrationScript(String name) throws IOException {


### PR DESCRIPTION
## Summary

Makes the migration extension work for automatic, deploy-time execution on **AEM as a Cloud Service** as well as **AEM 6.5 on-premises / AMS** and plain Sling. Modeled on how [AECU](https://github.com/valtech/aem-easy-content-upgrade) (immutable `/apps` scripts + cloud startup hook) and [ACM](https://github.com/wttech/acm) (composite-node-store readiness gating) solve the same problem.

The extension was already ACM-shaped (`/conf` scripts + `/var` state + checksum run-once + health checks), but had one critical gap: **nothing triggered a migration run after an AEMaaCS deploy** — the standard pipeline has no post-deploy step and no reliable install hook. Secondarily, `/conf` scripts are mutable content (author-only, deployed separately from the code image).

## Changes

- **Immutable + mutable script paths.** `scriptsBasePaths` (was single `scriptsBasePath`) defaults to `/apps/groovyconsole-migration-scripts` **and** `/conf/groovyconsole/scripts/migration`, searched in order, missing paths skipped. The immutable `/apps` path ships with the code image (present on author + publish, atomic with the bundle, tamper-proof). It is a dedicated top-level node — **not** `/apps/groovyconsole/...`, because the console's own `ui.apps` package has a replace filter on `/apps/groovyconsole` that would wipe scripts nested there on every deploy.
- **`MigrationStartupHook`** (new immediate component). On activation it waits for repository readiness, detects a composite node store (AEMaaCS), and enqueues a run of the pending scripts. Composite-store detection matches the AC Tool `RuntimeHelper` and ACM `Repo` implementations byte-for-byte (`hasPermission` guard + `hasCapability` on `/apps`). Configurable via `autoRunOnStartup` (`cloudOnly` default / `always` / `never`); logs the detection outcome at INFO so it can be verified from cloud logs on the first deploy.
- **Resource listener** now also watches the immutable `/apps` scripts path, so on-premises package installs can auto-run (on cloud `/apps` arrives via a container swap and is covered by the startup hook instead).
- **README**: new "Cloud vs on-premises" section and updated configuration tables.

## Behavior by environment

| Environment | Composite store? | Startup hook (default `cloudOnly`) | How migrations run |
|---|---|---|---|
| AEMaaCS | yes | fires automatically ~10s after each container start | hands-off, per deploy |
| AEM 6.5 on-prem / AMS | no | skipped by default | resource listener (opt-in), JMX, or `POST /bin/groovyconsole/migration`; or set `autoRunOnStartup=always` |
| AEM SDK / local | no | skipped by default | same as on-prem |

## Testing

- **Unit: 62 pass** — including 7 new `MigrationStartupHook` tests (composite detection incl. the permission-guard case, and every auto-run branch) and 2 new multi-path discovery tests.
- **Integration: full `-Pit` suite green on a real Sling instance** — `MigrationIT` 10/10 (new `testImmutableAppsPathScriptsAreDiscovered` proves `/apps` discovery end-to-end), plus all other IT modules. The startup hook activates cleanly and correctly skips on the single-node-store IT instance.
- aemanalyser validated the new component in the `all` package.