### PR TITLE
Add scheduled reports and a pluggable distribution SPI

### DIFF
--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/AbstractConsoleUiPageServlet.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/AbstractConsoleUiPageServlet.groovy
@@ -43,11 +43,23 @@ abstract class AbstractConsoleUiPageServlet extends SlingSafeMethodsServlet {
         bundleContext?.getServiceReference("com.day.cq.wcm.api.PageManagerFactory") != null
     }
 
+    /**
+     * Cache-busting token for the SPA's stable-named entry assets.  The bundle's last-modified time changes on
+     * every (re)deploy but is constant within one, so browsers refetch the entry after a deploy yet still cache it
+     * during normal use.  The entry then pulls in its content-hashed chunks, so a redeploy needs no manual reload.
+     */
+    protected String getAssetVersion() {
+        def bundle = bundleContext?.bundle
+
+        bundle ? Long.toString(bundle.lastModified) : "0"
+    }
+
     @Override
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
         def contextPath = request.contextPath ?: ""
         def configJson = new JsonBuilder([contextPath: contextPath, aem: isAem()]).toString()
+        def version = assetVersion
 
         response.contentType = "text/html"
         response.characterEncoding = "UTF-8"
@@ -59,12 +71,12 @@ abstract class AbstractConsoleUiPageServlet extends SlingSafeMethodsServlet {
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>${pageTitle}</title>
-    <link rel="stylesheet" href="${contextPath}${assetsPath}/${assetName}.css"/>
+    <link rel="stylesheet" href="${contextPath}${assetsPath}/${assetName}.css?v=${version}"/>
 </head>
 <body>
 <${appElement}></${appElement}>
 <script>window.__GC_CONFIG__ = ${configJson};</script>
-<script type="module" src="${contextPath}${assetsPath}/${assetName}.js"></script>
+<script type="module" src="${contextPath}${assetsPath}/${assetName}.js?v=${version}"></script>
 </body>
 </html>
 """)

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/AbstractConsoleUiPageServlet.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/AbstractConsoleUiPageServlet.groovy
@@ -1,8 +1,11 @@
 package be.orbinson.aem.groovy.console.api
 
 import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
 import org.apache.sling.api.SlingHttpServletRequest
 import org.apache.sling.api.SlingHttpServletResponse
+import org.apache.sling.api.resource.ResourceResolver
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet
 import org.osgi.framework.BundleContext
 
@@ -16,6 +19,7 @@ import javax.servlet.ServletException
  * Subclasses declare the servlet component and forward their <code>@Activate</code> method to
  * {@link #activate(BundleContext)}.
  */
+@Slf4j("LOG")
 abstract class AbstractConsoleUiPageServlet extends SlingSafeMethodsServlet {
 
     private volatile BundleContext bundleContext
@@ -48,6 +52,11 @@ abstract class AbstractConsoleUiPageServlet extends SlingSafeMethodsServlet {
             throws ServletException, IOException {
         def contextPath = request.contextPath ?: ""
         def configJson = new JsonBuilder([contextPath: contextPath, aem: isAem()]).toString()
+        def assets = resolveEntryAssets(request.resourceResolver)
+
+        def cssLinks = assets.css
+                .collect { href -> "    <link rel=\"stylesheet\" href=\"${contextPath}${href}\"/>" }
+                .join("\n")
 
         response.contentType = "text/html"
         response.characterEncoding = "UTF-8"
@@ -59,14 +68,50 @@ abstract class AbstractConsoleUiPageServlet extends SlingSafeMethodsServlet {
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>${pageTitle}</title>
-    <link rel="stylesheet" href="${contextPath}${assetsPath}/${assetName}.css"/>
+${cssLinks}
 </head>
 <body>
 <${appElement}></${appElement}>
 <script>window.__GC_CONFIG__ = ${configJson};</script>
-<script type="module" src="${contextPath}${assetsPath}/${assetName}.js"></script>
+<script type="module" src="${contextPath}${assets.js}"></script>
 </body>
 </html>
 """)
+    }
+
+    /**
+     * Resolve the SPA entry's JavaScript and stylesheet paths.  Prefers the content-hashed files listed in the
+     * Vite build manifest (so an unchanged asset keeps its URL and stays cached, while a changed one gets a fresh
+     * URL and is refetched — cache-busting without a query token, which would double-load the entry module).
+     * Falls back to the stable <code>&lt;assetName&gt;.js/.css</code> names when no manifest is present.
+     */
+    private Map<String, Object> resolveEntryAssets(ResourceResolver resourceResolver) {
+        def spaBase = assetsPath.endsWith("/assets") ? assetsPath[0..<(assetsPath.length() - "/assets".length())]
+                : assetsPath
+        def fallback = [js: "${assetsPath}/${assetName}.js".toString(),
+                        css: ["${assetsPath}/${assetName}.css".toString()]] as Map<String, Object>
+
+        try {
+            def manifestResource = resourceResolver?.getResource("${spaBase}/manifest.json")
+            def stream = manifestResource?.adaptTo(InputStream)
+
+            if (!stream) {
+                return fallback
+            }
+
+            def manifest = stream.withCloseable { new JsonSlurper().parse(it) }
+            def entry = manifest.values().find { it instanceof Map && it.isEntry && it.name == assetName }
+
+            if (!entry?.file) {
+                return fallback
+            }
+
+            [js: "${spaBase}/${entry.file}".toString(),
+             css: (entry.css ?: []).collect { css -> "${spaBase}/${css}".toString() }] as Map<String, Object>
+        } catch (Exception e) {
+            LOG.warn("could not read SPA manifest for {}; falling back to stable asset names", assetName, e)
+
+            fallback
+        }
     }
 }

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/AbstractConsoleUiPageServlet.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/AbstractConsoleUiPageServlet.groovy
@@ -1,7 +1,6 @@
 package be.orbinson.aem.groovy.console.api
 
 import groovy.json.JsonBuilder
-import groovy.json.JsonSlurper
 import groovy.util.logging.Slf4j
 import org.apache.sling.api.SlingHttpServletRequest
 import org.apache.sling.api.SlingHttpServletResponse
@@ -88,30 +87,13 @@ ${cssLinks}
     private Map<String, Object> resolveEntryAssets(ResourceResolver resourceResolver) {
         def spaBase = assetsPath.endsWith("/assets") ? assetsPath[0..<(assetsPath.length() - "/assets".length())]
                 : assetsPath
-        def fallback = [js: "${assetsPath}/${assetName}.js".toString(),
-                        css: ["${assetsPath}/${assetName}.css".toString()]] as Map<String, Object>
+        def entry = SpaManifest.entry(resourceResolver, spaBase, assetName)
 
-        try {
-            def manifestResource = resourceResolver?.getResource("${spaBase}/manifest.json")
-            def stream = manifestResource?.adaptTo(InputStream)
-
-            if (!stream) {
-                return fallback
-            }
-
-            def manifest = stream.withCloseable { new JsonSlurper().parse(it) }
-            def entry = manifest.values().find { it instanceof Map && it.isEntry && it.name == assetName }
-
-            if (!entry?.file) {
-                return fallback
-            }
-
-            [js: "${spaBase}/${entry.file}".toString(),
-             css: (entry.css ?: []).collect { css -> "${spaBase}/${css}".toString() }] as Map<String, Object>
-        } catch (Exception e) {
-            LOG.warn("could not read SPA manifest for {}; falling back to stable asset names", assetName, e)
-
-            fallback
+        if (entry.js) {
+            return entry
         }
+
+        [js: "${assetsPath}/${assetName}.js".toString(),
+         css: ["${assetsPath}/${assetName}.css".toString()]] as Map<String, Object>
     }
 }

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/AbstractConsoleUiPageServlet.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/AbstractConsoleUiPageServlet.groovy
@@ -43,23 +43,11 @@ abstract class AbstractConsoleUiPageServlet extends SlingSafeMethodsServlet {
         bundleContext?.getServiceReference("com.day.cq.wcm.api.PageManagerFactory") != null
     }
 
-    /**
-     * Cache-busting token for the SPA's stable-named entry assets.  The bundle's last-modified time changes on
-     * every (re)deploy but is constant within one, so browsers refetch the entry after a deploy yet still cache it
-     * during normal use.  The entry then pulls in its content-hashed chunks, so a redeploy needs no manual reload.
-     */
-    protected String getAssetVersion() {
-        def bundle = bundleContext?.bundle
-
-        bundle ? Long.toString(bundle.lastModified) : "0"
-    }
-
     @Override
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
         def contextPath = request.contextPath ?: ""
         def configJson = new JsonBuilder([contextPath: contextPath, aem: isAem()]).toString()
-        def version = assetVersion
 
         response.contentType = "text/html"
         response.characterEncoding = "UTF-8"
@@ -71,12 +59,12 @@ abstract class AbstractConsoleUiPageServlet extends SlingSafeMethodsServlet {
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>${pageTitle}</title>
-    <link rel="stylesheet" href="${contextPath}${assetsPath}/${assetName}.css?v=${version}"/>
+    <link rel="stylesheet" href="${contextPath}${assetsPath}/${assetName}.css"/>
 </head>
 <body>
 <${appElement}></${appElement}>
 <script>window.__GC_CONFIG__ = ${configJson};</script>
-<script type="module" src="${contextPath}${assetsPath}/${assetName}.js?v=${version}"></script>
+<script type="module" src="${contextPath}${assetsPath}/${assetName}.js"></script>
 </body>
 </html>
 """)

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/SpaManifest.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/SpaManifest.groovy
@@ -1,0 +1,76 @@
+package be.orbinson.aem.groovy.console.api
+
+import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
+import org.apache.sling.api.resource.ResourceResolver
+
+/**
+ * Resolves content-hashed SPA asset URLs from a Vite build manifest (<code>manifest.json</code> at the spa root),
+ * so console pages can link the exact hashed file: an unchanged asset keeps its URL and stays cached, a changed
+ * one gets a fresh URL and is refetched. Every lookup falls back gracefully (returns null / the input URL) when no
+ * manifest or matching entry is present, so a build without a manifest keeps working with stable names.
+ */
+@Slf4j("LOG")
+class SpaManifest {
+
+    private static final String MANIFEST_NAME = "manifest.json"
+
+    private static final String ASSETS_MARKER = "/spa/assets/"
+
+    private SpaManifest() {
+    }
+
+    /**
+     * Resolve the hashed js + css for a manifest entry, matched by its Vite chunk {@code name} (e.g. "index",
+     * "reports", "monaco"), under a spa base path such as {@code /apps/groovyconsole/spa}.
+     *
+     * @return map with {@code js} (absolute path or null) and {@code css} (list of absolute paths, possibly empty)
+     */
+    static Map<String, Object> entry(ResourceResolver resourceResolver, String spaBasePath, String name) {
+        def value = find(resourceResolver, spaBasePath, name)
+
+        if (!value) {
+            return [js: null, css: []] as Map<String, Object>
+        }
+
+        [js : value.file ? "${spaBasePath}/${value.file}".toString() : null,
+         css: (value.css ?: []).collect { css -> "${spaBasePath}/${css}".toString() }] as Map<String, Object>
+    }
+
+    /**
+     * Resolve a stable module URL (e.g. {@code /apps/groovyconsole-reports/spa/assets/reports-panel.js}) to its
+     * content-hashed URL via that spa's manifest.  Returns the input unchanged when it can't be resolved.
+     */
+    static String resolveModuleUrl(ResourceResolver resourceResolver, String moduleUrl) {
+        def index = moduleUrl == null ? -1 : moduleUrl.indexOf(ASSETS_MARKER)
+
+        if (index < 0) {
+            return moduleUrl
+        }
+
+        def spaBasePath = moduleUrl.substring(0, index + "/spa".length())
+        def name = moduleUrl.substring(index + ASSETS_MARKER.length()).replaceFirst(/\.js$/, "")
+        def value = find(resourceResolver, spaBasePath, name)
+
+        value?.file ? "${spaBasePath}/${value.file}".toString() : moduleUrl
+    }
+
+    private static Map find(ResourceResolver resourceResolver, String spaBasePath, String name) {
+        try {
+            def resource = resourceResolver?.getResource("${spaBasePath}/${MANIFEST_NAME}")
+            def stream = resource?.adaptTo(InputStream)
+
+            if (!stream) {
+                return null
+            }
+
+            def manifest = stream.withCloseable { new JsonSlurper().parse(it) }
+
+            manifest.values().find { value -> value instanceof Map && value.name == name } as Map
+        } catch (Exception e) {
+            LOG.warn("could not read SPA manifest under {}", spaBasePath, e)
+
+            null
+        }
+    }
+}

--- a/api/src/main/groovy/be/orbinson/aem/groovy/console/api/package-info.groovy
+++ b/api/src/main/groovy/be/orbinson/aem/groovy/console/api/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("20.1.0")
+@org.osgi.annotation.versioning.Version("20.0.0")
 package be.orbinson.aem.groovy.console.api;

--- a/bundle/src/main/groovy/be/orbinson/aem/groovy/console/components/ModernConsoleConfig.groovy
+++ b/bundle/src/main/groovy/be/orbinson/aem/groovy/console/components/ModernConsoleConfig.groovy
@@ -5,6 +5,7 @@ import static be.orbinson.aem.groovy.console.constants.GroovyConsoleConstants.US
 
 import be.orbinson.aem.groovy.console.GroovyConsoleService
 import be.orbinson.aem.groovy.console.api.ConsoleUiExtensionProvider
+import be.orbinson.aem.groovy.console.api.SpaManifest
 import be.orbinson.aem.groovy.console.audit.AuditService
 import be.orbinson.aem.groovy.console.configuration.ConfigurationService
 import be.orbinson.aem.groovy.console.impl.AEMDetector
@@ -21,6 +22,8 @@ import org.apache.sling.models.annotations.injectorspecific.Self
  */
 @Model(adaptables = SlingHttpServletRequest)
 class ModernConsoleConfig {
+
+    private static final String CORE_SPA_BASE = "/apps/groovyconsole/spa"
 
     @OSGiService
     private ConfigurationService configurationService
@@ -68,7 +71,31 @@ class ModernConsoleConfig {
                 auditRecord                : auditRecord,
                 uiExtensions               : (uiExtensionProviders ?: []).collectMany { provider ->
                     provider.moduleUrls ?: []
-                }
+                }.collect { url -> SpaManifest.resolveModuleUrl(request.resourceResolver, url as String) }
         ]).toString()
+    }
+
+    /** Content-hashed console entry script (from the Vite manifest), for the HTL page to link. */
+    String getScriptSrc() {
+        def entry = SpaManifest.entry(request.resourceResolver, CORE_SPA_BASE, "index")
+        def js = entry.js ?: "${CORE_SPA_BASE}/assets/index.js"
+
+        "${request.contextPath}${js}"
+    }
+
+    /** Content-hashed console stylesheets (Monaco chunk CSS + entry CSS), for the HTL page to link. */
+    List<String> getStyleSheets() {
+        def resolver = request.resourceResolver
+        def entry = SpaManifest.entry(resolver, CORE_SPA_BASE, "index")
+
+        def sheets
+        if (entry.js) {
+            def monaco = SpaManifest.entry(resolver, CORE_SPA_BASE, "monaco")
+            sheets = (monaco.css ?: []) + (entry.css ?: [])
+        } else {
+            sheets = ["${CORE_SPA_BASE}/assets/monaco.css".toString(), "${CORE_SPA_BASE}/assets/index.css".toString()]
+        }
+
+        sheets.collect { sheet -> "${request.contextPath}${sheet}".toString() }
     }
 }

--- a/extensions/migration/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/extensions/migration/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
     <!-- AEM Tools > Deployment entry so operators can reach the migration history UI (overlay; AEM-only).
-         merge mode: add this entry without replacing the shared nav folders, so it never wipes the core
-         console's or the reports extension's sibling entries (and they never wipe this one). -->
+         merge the shared nav folders (create if missing, never replace) so this package never removes the core
+         console's or the reports extension's sibling entries. -->
     <filter root="/apps/cq/core/content/nav" mode="merge">
         <include pattern="/apps/cq/core/content/nav"/>
         <include pattern="/apps/cq/core/content/nav/tools"/>
         <include pattern="/apps/cq/core/content/nav/tools/deployment"/>
-        <include pattern="/apps/cq/core/content/nav/tools/deployment/groovyconsole-migrations(.*)?"/>
     </filter>
+    <!-- own only this leaf entry, so it is always (re)created even under a pre-existing shared folder -->
+    <filter root="/apps/cq/core/content/nav/tools/deployment/groovyconsole-migrations"/>
     <!-- the migration SPA assets (built by extensions/migration/ui.frontend), on a migration-owned path -->
     <filter root="/apps/groovyconsole-migration"/>
 </workspaceFilter>

--- a/extensions/migration/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/extensions/migration/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
     <!-- AEM Tools > Deployment entry so operators can reach the migration history UI (overlay; AEM-only).
-         Fine-grained includes so other entries under the shared nav nodes are left untouched. -->
-    <filter root="/apps/cq/core/content/nav">
+         merge mode: add this entry without replacing the shared nav folders, so it never wipes the core
+         console's or the reports extension's sibling entries (and they never wipe this one). -->
+    <filter root="/apps/cq/core/content/nav" mode="merge">
         <include pattern="/apps/cq/core/content/nav"/>
         <include pattern="/apps/cq/core/content/nav/tools"/>
         <include pattern="/apps/cq/core/content/nav/tools/deployment"/>

--- a/extensions/migration/ui.frontend/vite.config.ts
+++ b/extensions/migration/ui.frontend/vite.config.ts
@@ -27,6 +27,9 @@ export default defineConfig({
     outDir: '../ui.apps/src/main/content/jcr_root/apps/groovyconsole-migration/spa',
     emptyOutDir: true,
     target: 'es2021',
+    // emit a manifest so the page servlet and the console (for the panel URL) can link the content-hashed
+    // entries for cache-busting; written at the spa root as manifest.json
+    manifest: 'manifest.json',
     rollupOptions: {
       input: {
         // the migration history UI (migration.html)
@@ -35,10 +38,11 @@ export default defineConfig({
         'migration-panel': resolve(__dirname, 'src/migration-console-panel.ts'),
       },
       output: {
-        // Stable file names so migration.html / the extension provider can reference them without a manifest.
-        entryFileNames: 'assets/[name].js',
-        chunkFileNames: 'assets/[name].js',
-        assetFileNames: 'assets/[name][extname]',
+        // Content-hash the entries, chunks and assets for cache-busting; the page servlet and the console
+        // resolve the hashed names from the manifest.
+        entryFileNames: 'assets/[name]-[hash].js',
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash][extname]',
       },
     },
   },

--- a/extensions/reports/README.md
+++ b/extensions/reports/README.md
@@ -209,7 +209,10 @@ itself.
 
 Distributors are discovered from registered
 `be.orbinson.aem.groovy.console.reports.ReportDistributor` services (mirroring the exporter SPI), so a custom
-distributor registered as an OSGi service surfaces automatically in the API and UI. Two ship built in:
+distributor registered as an OSGi service surfaces automatically in the API and UI. Only distributors that report
+themselves **available** (`ReportDistributor.isAvailable()`) are offered as a destination — the filesystem
+distributor is available only when enabled, and the email distributor only when a mail service is bound — so
+authors are never shown a destination that would fail. Two ship built in:
 
 - **Email** (`email`) — attaches the rendered export and sends it via AEM's mail service (SMTP is configured on
   the platform, as for the console's own notifications). Config: `recipients` (comma/semicolon/space separated)

--- a/extensions/reports/README.md
+++ b/extensions/reports/README.md
@@ -39,7 +39,9 @@ works without this package; installing it adds the reports feature.
 - [Writing the script](#writing-the-script)
 - [Column types](#column-types)
 - [Execution model](#execution-model)
+- [Scheduling](#scheduling)
 - [Exports](#exports)
+- [Distribution](#distribution)
 - [Access control](#access-control)
 - [User interfaces](#user-interfaces)
 - [Configuration](#configuration)
@@ -130,6 +132,54 @@ The complete result is persisted as a gzipped JSON binary (`jcr:data`) under
 `/var/groovyconsole/reports/executions`. **Every row is stored** — the UI paginates and exports from the persisted
 result without re-running the script. Old executions are purged on a configurable schedule.
 
+## Scheduling
+
+A report can run **unattended on a cron schedule**. Enable it in the editor's *Schedule* section (or set a
+`schedule` child node on the definition) with a Quartz-style cron expression and, optionally, fixed parameter
+values used for the scheduled run (there is no interactive form). Each scheduled report maps to exactly one Sling
+scheduled job on the topic `groovyconsole/reports/job`, keyed on the definition's node path, so schedules persist
+across restarts and, in a cluster, fire on a single instance. Saving the report reconciles the job (create /
+update / remove); deleting the report removes it. When the job fires the report runs through the normal
+[execution model](#execution-model) and its configured [distributions](#distribution) are applied to the result.
+
+The cron expression is the Sling scheduler's Quartz form — 6 or 7 whitespace-separated fields
+(`seconds minutes hours day-of-month month day-of-week [year]`), e.g. `0 0 6 * * ?` for 06:00 daily. It is
+validated when the report is saved; an invalid expression is rejected with a `400` before anything is persisted.
+**Sub-minute schedules are not allowed**: the seconds field must be a fixed value (0–59), so a report cannot be
+set to run every second.
+
+### Code-deployed schedules
+
+Reports authored in the UI live under `/conf`. Reports **deployed in code** are auto-discovered from the immutable
+drop-zone **`/apps/groovyconsole-reports-definitions`**: on startup, and whenever that tree changes (e.g. a content
+package install), their enabled schedules are registered and schedules for definitions that no longer exist are
+removed. Ship your definitions there in their own content package (a sibling of the reports package's own
+`/apps/groovyconsole-reports`, so neither package's install wipes the other). Because `/apps` cannot be written at
+runtime through the repository's write servlets, definitions found here are trusted to run under the executor
+service user (see below).
+
+### Run-as identity
+
+A scheduled run has no request user, so it needs an identity. There are two, by how the report was created:
+
+- **Scheduled through the UI/API** — the report runs **as its author**, with that user's own permissions, so it
+  sees exactly what they can see. The author is set server-side (`runAs`/`scheduledBy` in the request body are
+  ignored): a user can only ever schedule a report to run **as themselves**, never as another user, so scheduling
+  can never be used to gain access. This is enabled by a self-scoped impersonation grant made when the schedule is
+  saved — a user may grant a system user impersonation over their *own* account, so no privileged
+  user-administration is involved. If that author later can't be impersonated (grant removed, user disabled), the
+  run fails closed with a clear error rather than running with the wrong rights.
+- **Deployed in code** (a definition installed by a content package, with no `runAs`) — the report runs as the
+  dedicated executor service user **`aem-groovy-console-reports-executor`**, which ships with `jcr:read` on
+  `/content`. This is the identity for reports shipped and vetted by developers. Scope its ACLs to the trees your
+  code-deployed reports need.
+
+The executor is a separate identity from the minimal bookkeeping service user
+(`aem-groovy-console-reports-service`, which only persists executions under `/var`), so execution rights and
+bookkeeping rights stay cleanly separated. Because a report editor can also edit the executable Groovy, treat
+write access to `/conf/groovyconsole/reports` as the trust boundary and restrict it accordingly (see
+[Access control](#access-control)).
+
 ## Exports
 
 Export formats are discovered from registered `be.orbinson.aem.groovy.console.reports.ReportExporter` services;
@@ -147,6 +197,44 @@ registering a new one automatically surfaces it in the API and UI.
 
 A column can be excluded from exports (UI-only) by declaring it with `exported = false`:
 `data.column('Edit', ReportColumnType.LINK, false)`.
+
+## Distribution
+
+A report can **distribute** its result to one or more destinations. Each *distribution target* pairs a distributor
+with an [export format](#exports), so any registered exporter (CSV, XLSX, …) can be delivered. Targets are
+configured in the editor's *Distribution* section and stored on the definition; they are applied automatically
+when a **scheduled** run finishes successfully, and on demand for any completed run via **Distribute now** in the
+run view. A distribution failure is recorded on the execution (`distributionErrors`) but never fails the run
+itself.
+
+Distributors are discovered from registered
+`be.orbinson.aem.groovy.console.reports.ReportDistributor` services (mirroring the exporter SPI), so a custom
+distributor registered as an OSGi service surfaces automatically in the API and UI. Two ship built in:
+
+- **Email** (`email`) — attaches the rendered export and sends it via AEM's mail service (SMTP is configured on
+  the platform, as for the console's own notifications). Config: `recipients` (comma/semicolon/space separated)
+  and an optional `subject`. Inactive on plain Sling with no mail service. An optional **recipient-domain
+  allowlist** bounds where reports may be sent, via
+  `be.orbinson.aem.groovy.console.reports.impl.EmailReportDistributorConfig`:
+
+  | Property                  | Default | Meaning                                                                        |
+  |---------------------------|---------|--------------------------------------------------------------------------------|
+  | `allowedRecipientDomains` | (empty) | Recipient domains reports may be sent to. Empty means any address is allowed.  |
+
+  When set, every recipient's domain must match an entry or the whole distribution is rejected (recorded in
+  `distributionErrors`); leave it empty to send anywhere.
+- **Filesystem** (`filesystem`) — writes the rendered export to a directory on the local filesystem. Config:
+  `directory` and an optional `filename` (defaults to `<report>-<timestamp>.<ext>`). **Disabled by default** —
+  writing to disk is sensitive, so enable it deliberately via
+  `be.orbinson.aem.groovy.console.reports.impl.FilesystemReportDistributorConfig`:
+
+  | Property               | Default | Meaning                                                                     |
+  |------------------------|---------|-----------------------------------------------------------------------------|
+  | `enabled`              | `false` | Enable the filesystem distributor.                                          |
+  | `allowedRootDirectory` | (empty) | Absolute path every target directory must resolve within. Required to use.  |
+
+  Target directories and file names are resolved against `allowedRootDirectory` with a canonical-path check, so
+  `..` segments or an absolute path that escapes the configured root are rejected.
 
 ## Access control
 

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportDistributor.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportDistributor.groovy
@@ -29,6 +29,15 @@ interface ReportDistributor {
     String getName()
 
     /**
+     * Whether this distributor is currently usable — e.g. enabled and configured.  Unavailable distributors are
+     * hidden from the reports UI so authors are never offered a destination that would fail.  Implementations that
+     * are always usable simply return true.
+     *
+     * @return true when the distributor can accept distributions
+     */
+    boolean isAvailable()
+
+    /**
      * Distribute the result of a completed execution.  Implementations should throw {@link ReportException} on
      * failure so the caller can record it against the execution.
      *

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportDistributor.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportDistributor.groovy
@@ -1,0 +1,40 @@
+package be.orbinson.aem.groovy.console.reports
+
+import be.orbinson.aem.groovy.console.reports.data.ReportData
+import be.orbinson.aem.groovy.console.reports.model.ReportDistributionTarget
+import be.orbinson.aem.groovy.console.reports.model.ReportExecution
+import org.osgi.annotation.versioning.ConsumerType
+
+/**
+ * Services may implement this interface to distribute a completed report execution somewhere (e.g. by email or to
+ * the filesystem).  Available distributors are discovered dynamically; registering a new distributor automatically
+ * surfaces it in the reports API and UI.  Distributors render the tabular result through a {@link ReportExporter}
+ * (chosen via {@link ReportDistributionTarget#getFormat()}), so any registered export format can be distributed.
+ */
+@ConsumerType
+interface ReportDistributor {
+
+    /**
+     * Distributor identifier, e.g. <code>email</code>.  Referenced by {@link ReportDistributionTarget#getDistributorId()}.
+     *
+     * @return distributor identifier
+     */
+    String getId()
+
+    /**
+     * Human-readable name for display in the UI.
+     *
+     * @return display name
+     */
+    String getName()
+
+    /**
+     * Distribute the result of a completed execution.  Implementations should throw {@link ReportException} on
+     * failure so the caller can record it against the execution.
+     *
+     * @param execution completed execution metadata
+     * @param reportData tabular result to distribute
+     * @param target distribution target holding the export format and distributor-specific configuration
+     */
+    void distribute(ReportExecution execution, ReportData reportData, ReportDistributionTarget target)
+}

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportDistributorRegistry.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportDistributorRegistry.groovy
@@ -1,0 +1,26 @@
+package be.orbinson.aem.groovy.console.reports
+
+import org.osgi.annotation.versioning.ProviderType
+
+/**
+ * Registry of all available report distributors.  Distributors are API-driven: the set of available distributors
+ * is the set of registered {@link ReportDistributor} services.
+ */
+@ProviderType
+interface ReportDistributorRegistry {
+
+    /**
+     * Get all registered distributors, sorted by id.
+     *
+     * @return list of distributors
+     */
+    List<ReportDistributor> getDistributors()
+
+    /**
+     * Get the distributor for the given id.
+     *
+     * @param id distributor identifier
+     * @return distributor or null if no distributor is registered for the id
+     */
+    ReportDistributor getDistributor(String id)
+}

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportExecutionService.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportExecutionService.groovy
@@ -1,6 +1,7 @@
 package be.orbinson.aem.groovy.console.reports
 
 import be.orbinson.aem.groovy.console.reports.model.ReportDefinition
+import be.orbinson.aem.groovy.console.reports.model.ReportDistributionTarget
 import be.orbinson.aem.groovy.console.reports.model.ReportExecution
 import be.orbinson.aem.groovy.console.reports.model.ReportPreview
 import org.apache.sling.api.resource.ResourceResolver
@@ -30,6 +31,20 @@ interface ReportExecutionService {
                             ResourceResolver resourceResolver)
 
     /**
+     * Start a report execution and apply the given distribution targets to the result once it finishes
+     * successfully.  Behaves exactly like {@link #execute(ReportDefinition, Map, ResourceResolver)} otherwise;
+     * distribution failures are recorded against the execution but do not fail the run.
+     *
+     * @param reportDefinition report to execute
+     * @param parameterValues raw (string) parameter values
+     * @param resourceResolver resolver the script executes under (a detached clone is used)
+     * @param distributionTargets distribution targets to apply on success (may be empty)
+     * @return the started execution
+     */
+    ReportExecution execute(ReportDefinition reportDefinition, Map<String, String> parameterValues,
+                            ResourceResolver resourceResolver, List<ReportDistributionTarget> distributionTargets)
+
+    /**
      * Run a report script once for a "try out" preview WITHOUT persisting an execution.  Used by the report
      * editor to debug an unsaved script: it runs through the same {@code ReportScriptContext} (so the
      * <code>report</code> and <code>params</code> bindings and typed result behave exactly as in a real run)
@@ -43,6 +58,18 @@ interface ReportExecutionService {
      */
     ReportPreview preview(ReportDefinition reportDefinition, Map<String, String> parameterValues,
                           ResourceResolver resourceResolver)
+
+    /**
+     * Apply the given distribution targets to an already-completed successful execution, using its persisted
+     * result.  Distribution failures are recorded against the execution.  Used for on-demand distribution of a
+     * run that has already finished.
+     *
+     * @param executionId execution ID (must be a successful execution)
+     * @param distributionTargets distribution targets to apply
+     * @throws be.orbinson.aem.groovy.console.reports.ReportException when the execution is missing, not
+     *         successful, or has no stored result
+     */
+    void distribute(String executionId, List<ReportDistributionTarget> distributionTargets)
 
     /**
      * Get all executions of a report, newest first.

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportScheduleService.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportScheduleService.groovy
@@ -1,0 +1,36 @@
+package be.orbinson.aem.groovy.console.reports
+
+import be.orbinson.aem.groovy.console.reports.model.ReportDefinition
+import org.osgi.annotation.versioning.ProviderType
+
+/**
+ * Keeps the set of registered cron schedules in sync with report definitions.  Backed by Sling's job scheduler,
+ * so schedules persist across restarts and, in a cluster, fire on a single instance.
+ */
+@ProviderType
+interface ReportScheduleService {
+
+    /**
+     * Reconcile the scheduled job for a report definition: (re)register it when the definition has an enabled
+     * schedule and a valid cron expression, or remove it otherwise.  Keyed on the definition's node path, so it is
+     * safe to call on every save and independent of the report name.
+     *
+     * @param reportDefinition report definition whose schedule to apply (its {@code path} must be set)
+     */
+    void reconcile(ReportDefinition reportDefinition)
+
+    /**
+     * Remove any scheduled job registered for the report definition at the given node path (e.g. on delete).
+     *
+     * @param reportPath definition node path
+     */
+    void unschedule(String reportPath)
+
+    /**
+     * Discover report definitions deployed in code under the immutable
+     * {@link be.orbinson.aem.groovy.console.reports.constants.ReportsConstants#PATH_APPS_REPORTS_FOLDER} drop-zone
+     * and synchronise their schedules: register jobs for enabled definitions and drop jobs for definitions that no
+     * longer exist there.  Called on activation and whenever that tree changes (e.g. a content package install).
+     */
+    void reconcileDeployedReports()
+}

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportService.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/ReportService.groovy
@@ -30,6 +30,26 @@ interface ReportService {
     ReportDefinition getReport(ResourceResolver resourceResolver, String name)
 
     /**
+     * Get the report definition at an exact repository path, or null if there is none there or it is not readable.
+     * Unlike {@link #getReport}, this resolves definitions anywhere (e.g. the immutable <code>/apps</code>
+     * drop-zone), which is how scheduled jobs load the definition they were registered for.
+     *
+     * @param resourceResolver requesting resolver
+     * @param path full definition node path
+     * @return report definition or null
+     */
+    ReportDefinition getReportAtPath(ResourceResolver resourceResolver, String path)
+
+    /**
+     * Recursively collect the report definitions under a base path (used to discover code-deployed definitions).
+     *
+     * @param resourceResolver requesting resolver
+     * @param basePath folder to scan
+     * @return report definitions found beneath the base path (empty when the path is missing or unreadable)
+     */
+    List<ReportDefinition> findReports(ResourceResolver resourceResolver, String basePath)
+
+    /**
      * Create or update a report definition.  The write uses the given resolver, so it fails when the user
      * lacks JCR write access to the reports tree.
      *

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/constants/ReportsConstants.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/constants/ReportsConstants.groovy
@@ -4,7 +4,21 @@ class ReportsConstants {
 
     public static final String SYSTEM_USER_NAME = "aem-groovy-console-reports-service"
 
+    /** Dedicated identity that executes scheduled reports (reads content); separate from the bookkeeping user. */
+    public static final String EXECUTOR_SYSTEM_USER_NAME = "aem-groovy-console-reports-executor"
+
+    /** Sling subservice name mapped to the executor system user. */
+    public static final String EXECUTOR_SUBSERVICE = "executor"
+
     public static final String PATH_REPORTS_FOLDER = "/conf/groovyconsole/reports"
+
+    /**
+     * Immutable drop-zone for report definitions deployed in code (content packages).  Definitions found here are
+     * auto-discovered and scheduled; because the location is under <code>/apps</code> it cannot be written at
+     * runtime through the SlingPostServlet, so its definitions are trusted to run under the executor service user.
+     * A sibling of <code>/apps/groovyconsole-reports</code> so the reports package's replace filter never wipes it.
+     */
+    public static final String PATH_APPS_REPORTS_FOLDER = "/apps/groovyconsole-reports-definitions"
 
     public static final String PATH_EXECUTIONS_FOLDER = "/var/groovyconsole/reports/executions"
 
@@ -18,7 +32,20 @@ class ReportsConstants {
 
     public static final String PARAMETERS_NODE_NAME = "parameters"
 
+    public static final String SCHEDULE_NODE_NAME = "schedule"
+
+    public static final String DISTRIBUTIONS_NODE_NAME = "distributions"
+
     public static final String RESULT_NODE_NAME = "result"
+
+    // Sling job topic for scheduled report runs
+
+    public static final String JOB_TOPIC = "groovyconsole/reports/job"
+
+    public static final String JOB_PROPERTY_REPORT_NAME = "reportName"
+
+    /** Full node path of the scheduled report definition; the consumer loads the definition from here at run time. */
+    public static final String JOB_PROPERTY_REPORT_PATH = "reportPath"
 
     // request parameters
 

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/constants/ReportsConstants.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/constants/ReportsConstants.groovy
@@ -13,10 +13,9 @@ class ReportsConstants {
     public static final String PATH_REPORTS_FOLDER = "/conf/groovyconsole/reports"
 
     /**
-     * Immutable drop-zone for report definitions deployed in code (content packages).  Definitions found here are
-     * auto-discovered and scheduled; because the location is under <code>/apps</code> it cannot be written at
-     * runtime through the SlingPostServlet, so its definitions are trusted to run under the executor service user.
-     * A sibling of <code>/apps/groovyconsole-reports</code> so the reports package's replace filter never wipes it.
+     * Immutable location for report definitions deployed in code (content packages).  Definitions here are
+     * auto-discovered, scheduled and run under the executor service user.  A dedicated sibling of
+     * <code>/apps/groovyconsole-reports</code>, so installing either package leaves the other untouched.
      */
     public static final String PATH_APPS_REPORTS_FOLDER = "/apps/groovyconsole-reports-definitions"
 

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/ReportDefinition.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/ReportDefinition.groovy
@@ -11,6 +11,9 @@ class ReportDefinition {
     /** Unique report name (node name, URL-safe). */
     String name
 
+    /** Full repository path of the definition node; identifies the schedule and its trust origin (/conf vs /apps). */
+    String path
+
     /** Display title. */
     String title
 
@@ -28,6 +31,12 @@ class ReportDefinition {
 
     /** Declared parameters. */
     List<ReportParameter> parameters = []
+
+    /** Optional cron schedule; null or disabled means the report only runs on demand. */
+    ReportSchedule schedule
+
+    /** Distribution targets applied to the result when the report finishes (scheduled or on demand). */
+    List<ReportDistributionTarget> distributions = []
 
     Calendar created
 

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/ReportDistributionTarget.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/ReportDistributionTarget.groovy
@@ -1,0 +1,21 @@
+package be.orbinson.aem.groovy.console.reports.model
+
+import groovy.transform.ToString
+
+/**
+ * A single distribution target configured on a report definition: which {@code ReportDistributor} to use, which
+ * export format to render, and distributor-specific configuration (recipients, directory, ...).  Persisted as a
+ * child node under the report definition's <code>distributions</code> node and applied when the report finishes.
+ */
+@ToString(includePackage = false, includeNames = true)
+class ReportDistributionTarget {
+
+    /** Id of the {@code ReportDistributor} to use, e.g. "email" or "filesystem". */
+    String distributorId
+
+    /** Export format id ({@code ReportExporter.format}) used to render the payload, e.g. "csv" or "xlsx". */
+    String format
+
+    /** Distributor-specific configuration (e.g. recipients and subject, or directory and filename). */
+    Map<String, Object> config = [:]
+}

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/ReportExecution.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/ReportExecution.groovy
@@ -40,4 +40,7 @@ class ReportExecution {
     String output
 
     String exceptionStackTrace
+
+    /** Distribution failures recorded after a successful run (empty when all distributions succeeded). */
+    List<String> distributionErrors = []
 }

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/ReportSchedule.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/ReportSchedule.groovy
@@ -26,6 +26,7 @@ class ReportSchedule {
     /** User id that configured the schedule; the run-as authorization is checked against this principal. */
     String scheduledBy
 
-    /** Fixed raw (string) parameter values used for scheduled runs (there is no interactive form). */
-    Map<String, String> parameterValues = [:]
+    /** Fixed parameter values used for scheduled runs: a String, or a List of Strings for a {@code multiple}
+     *  parameter (matching how the coercer and run form treat values). */
+    Map<String, Object> parameterValues = [:]
 }

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/ReportSchedule.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/ReportSchedule.groovy
@@ -1,0 +1,31 @@
+package be.orbinson.aem.groovy.console.reports.model
+
+import groovy.transform.ToString
+
+/**
+ * Cron schedule configured on a report definition.  When enabled, the report runs unattended on the cron
+ * expression and its configured distributions are applied to the result.
+ *
+ * <p>A scheduled run has no request user, so it runs as {@link #runAs}.  Run-as is authorization-gated: it
+ * defaults to the configurer ({@link #scheduledBy}) and may only name another user the configurer is permitted
+ * to impersonate.  {@link #scheduledBy} is set server-side and the gate is re-checked at execution time, so a
+ * schedule can never run with more rights than the person who configured it.
+ */
+@ToString(includePackage = false, includeNames = true)
+class ReportSchedule {
+
+    /** Whether the report runs on the schedule. */
+    boolean enabled
+
+    /** Quartz-style cron expression (as accepted by Sling's job scheduler). */
+    String cronExpression
+
+    /** User id the scheduled report runs as.  Defaults to {@link #scheduledBy}. */
+    String runAs
+
+    /** User id that configured the schedule; the run-as authorization is checked against this principal. */
+    String scheduledBy
+
+    /** Fixed raw (string) parameter values used for scheduled runs (there is no interactive form). */
+    Map<String, String> parameterValues = [:]
+}

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/package-info.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package be.orbinson.aem.groovy.console.reports.model;

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/package-info.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/model/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.0.0")
 package be.orbinson.aem.groovy.console.reports.model;

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/package-info.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.0.0")
 package be.orbinson.aem.groovy.console.reports;

--- a/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/package-info.groovy
+++ b/extensions/reports/api/src/main/groovy/be/orbinson/aem/groovy/console/reports/package-info.groovy
@@ -1,3 +1,3 @@
 @org.osgi.annotation.bundle.Export
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package be.orbinson.aem.groovy.console.reports;

--- a/extensions/reports/bundle/pom.xml
+++ b/extensions/reports/bundle/pom.xml
@@ -24,6 +24,20 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bnd-process</id>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                Import-Package: com.day.cq.*;resolution:=optional,org.apache.commons.mail;resolution:=optional,*
+                                DynamicImport-Package: *
+                                ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -92,6 +106,16 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <!-- Mail (email distributor); provided at runtime by AEM, optional imports for Sling -->
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-email</artifactId>
         </dependency>
 
         <!-- Groovy -->

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/distributor/EmailReportDistributor.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/distributor/EmailReportDistributor.groovy
@@ -1,0 +1,142 @@
+package be.orbinson.aem.groovy.console.reports.distributor
+
+import be.orbinson.aem.groovy.console.reports.ReportDistributor
+import be.orbinson.aem.groovy.console.reports.ReportException
+import be.orbinson.aem.groovy.console.reports.ReportExporterRegistry
+import be.orbinson.aem.groovy.console.reports.data.ReportData
+import be.orbinson.aem.groovy.console.reports.impl.EmailReportDistributorConfig
+import be.orbinson.aem.groovy.console.reports.model.ReportDistributionTarget
+import be.orbinson.aem.groovy.console.reports.model.ReportExecution
+import com.day.cq.mailer.MailService
+import groovy.util.logging.Slf4j
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Modified
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceCardinality
+import org.osgi.service.component.annotations.ReferencePolicy
+import org.apache.commons.mail.EmailAttachment
+import org.apache.commons.mail.MultiPartEmail
+import org.osgi.service.metatype.annotations.Designate
+
+import javax.mail.util.ByteArrayDataSource
+import java.nio.charset.StandardCharsets
+
+/**
+ * Distributes report results by email, attaching the rendered export.  Uses the AEM Day CQ mail service, whose SMTP
+ * settings are configured on the platform; on plain Sling (no mail service) this component stays inactive.
+ *
+ * <p>An optional recipient-domain allowlist bounds where reports may be sent; when it is empty reports may go to
+ * any address.
+ */
+@Component(service = ReportDistributor, immediate = true)
+@Designate(ocd = EmailReportDistributorConfig)
+@Slf4j("LOG")
+class EmailReportDistributor implements ReportDistributor {
+
+    static final String ID = "email"
+
+    /** Target config key: recipients, either a list or a comma/semicolon/whitespace separated string. */
+    static final String CONFIG_RECIPIENTS = "recipients"
+
+    /** Target config key: optional subject line. */
+    static final String CONFIG_SUBJECT = "subject"
+
+    static final String DEFAULT_SUBJECT = "AEM Groovy Console Report"
+
+    @Reference
+    private ReportExporterRegistry exporterRegistry
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    private volatile MailService mailService
+
+    private volatile Set<String> allowedRecipientDomains = [] as Set
+
+    @Activate
+    @Modified
+    void activate(EmailReportDistributorConfig config) {
+        allowedRecipientDomains = (config.allowedRecipientDomains() ?: new String[0])
+                .collect { it?.trim()?.toLowerCase() }
+                .findAll { it } as Set
+    }
+
+    @Override
+    String getId() {
+        ID
+    }
+
+    @Override
+    String getName() {
+        "Email"
+    }
+
+    @Override
+    void distribute(ReportExecution execution, ReportData reportData, ReportDistributionTarget target) {
+        if (!mailService) {
+            throw new ReportException("mail service unavailable")
+        }
+
+        def recipients = recipients(target)
+
+        if (!recipients) {
+            throw new ReportException("email distribution target has no recipients configured")
+        }
+
+        assertRecipientsAllowed(recipients, allowedRecipientDomains)
+
+        def payload = ReportPayload.render(exporterRegistry, target.format, execution, reportData)
+        def subject = (target.config[CONFIG_SUBJECT] as String)?.trim() ?: DEFAULT_SUBJECT
+
+        def email = new MultiPartEmail()
+
+        recipients.each { recipient -> email.addTo(recipient) }
+
+        email.subject = subject
+        email.charset = StandardCharsets.UTF_8.name()
+        email.setMsg(body(execution))
+        email.attach(new ByteArrayDataSource(payload.bytes, payload.contentType), payload.fileName,
+                "Report ${execution.reportName}", EmailAttachment.ATTACHMENT)
+
+        LOG.debug("sending report {} to {}", execution.reportName, recipients)
+
+        mailService.send(email)
+    }
+
+    // Reject the whole distribution if any recipient falls outside the configured domain allowlist. An empty
+    // allowlist means unrestricted. Fail rather than silently drop recipients so a misconfiguration is visible.
+    static void assertRecipientsAllowed(Set<String> recipients, Set<String> allowedDomains) {
+        if (!allowedDomains) {
+            return
+        }
+
+        def rejected = recipients.findAll { recipient ->
+            def at = recipient.lastIndexOf("@")
+            def domain = at >= 0 ? recipient.substring(at + 1).trim().toLowerCase() : ""
+
+            !domain || !allowedDomains.contains(domain)
+        }
+
+        if (rejected) {
+            throw new ReportException("recipient(s) not permitted by the email domain allowlist: " +
+                    "${rejected.join(", ")}")
+        }
+    }
+
+    private static Set<String> recipients(ReportDistributionTarget target) {
+        def value = target.config[CONFIG_RECIPIENTS]
+
+        if (value instanceof Collection) {
+            return value.collect { it as String }.findAll { it?.trim() }*.trim() as Set
+        }
+
+        if (value instanceof String) {
+            return value.split("[,;\\s]+").findAll { it } as Set
+        }
+
+        [] as Set
+    }
+
+    private static String body(ReportExecution execution) {
+        "Report '${execution.reportName}' completed with status ${execution.status}. See the attached ${execution.reportName} export."
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/distributor/EmailReportDistributor.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/distributor/EmailReportDistributor.groovy
@@ -71,6 +71,11 @@ class EmailReportDistributor implements ReportDistributor {
     }
 
     @Override
+    boolean isAvailable() {
+        mailService != null
+    }
+
+    @Override
     void distribute(ReportExecution execution, ReportData reportData, ReportDistributionTarget target) {
         if (!mailService) {
             throw new ReportException("mail service unavailable")

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/distributor/FilesystemReportDistributor.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/distributor/FilesystemReportDistributor.groovy
@@ -1,0 +1,101 @@
+package be.orbinson.aem.groovy.console.reports.distributor
+
+import be.orbinson.aem.groovy.console.reports.ReportDistributor
+import be.orbinson.aem.groovy.console.reports.ReportException
+import be.orbinson.aem.groovy.console.reports.ReportExporterRegistry
+import be.orbinson.aem.groovy.console.reports.data.ReportData
+import be.orbinson.aem.groovy.console.reports.impl.FilesystemReportDistributorConfig
+import be.orbinson.aem.groovy.console.reports.model.ReportDistributionTarget
+import be.orbinson.aem.groovy.console.reports.model.ReportExecution
+import groovy.util.logging.Slf4j
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Modified
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.metatype.annotations.Designate
+
+import java.nio.file.Files
+
+/**
+ * Distributes report results to the local filesystem.  Disabled by default; when enabled, every target directory
+ * must resolve within the configured allowed root directory (canonical-path check), which prevents a report editor
+ * from writing outside the sandbox via {@code ..} segments or an absolute path.
+ */
+@Component(service = ReportDistributor, immediate = true)
+@Designate(ocd = FilesystemReportDistributorConfig)
+@Slf4j("LOG")
+class FilesystemReportDistributor implements ReportDistributor {
+
+    static final String ID = "filesystem"
+
+    /** Target config key: directory to write to, resolved within the allowed root. */
+    static final String CONFIG_DIRECTORY = "directory"
+
+    /** Target config key: optional explicit file name; defaults to {@code <report>-<timestamp>.<ext>}. */
+    static final String CONFIG_FILENAME = "filename"
+
+    @Reference
+    private ReportExporterRegistry exporterRegistry
+
+    private volatile boolean enabled
+
+    private volatile String allowedRootDirectory
+
+    @Activate
+    @Modified
+    void activate(FilesystemReportDistributorConfig config) {
+        enabled = config.enabled()
+        allowedRootDirectory = config.allowedRootDirectory()?.trim()
+    }
+
+    @Override
+    String getId() {
+        ID
+    }
+
+    @Override
+    String getName() {
+        "Filesystem"
+    }
+
+    @Override
+    void distribute(ReportExecution execution, ReportData reportData, ReportDistributionTarget target) {
+        if (!enabled) {
+            throw new ReportException("filesystem distributor is disabled")
+        }
+
+        if (!allowedRootDirectory) {
+            throw new ReportException("filesystem distributor has no allowed root directory configured")
+        }
+
+        def directory = (target.config[CONFIG_DIRECTORY] as String)?.trim()
+
+        if (!directory) {
+            throw new ReportException("filesystem distribution target has no directory configured")
+        }
+
+        def payload = ReportPayload.render(exporterRegistry, target.format, execution, reportData)
+        def fileName = (target.config[CONFIG_FILENAME] as String)?.trim() ?: payload.fileName
+
+        def root = new File(allowedRootDirectory).canonicalFile
+        def targetDirectory = resolveWithin(root, directory)
+        def targetFile = resolveWithin(targetDirectory, fileName)
+
+        Files.createDirectories(targetDirectory.toPath())
+        targetFile.bytes = payload.bytes
+
+        LOG.info("distributed report {} to {}", execution.reportName, targetFile.absolutePath)
+    }
+
+    // Resolve child within base, rejecting anything that canonicalizes outside base (blocks .. and absolute escapes).
+    private static File resolveWithin(File base, String child) {
+        def candidate = new File(child)
+        def resolved = (candidate.absolute ? candidate : new File(base, child)).canonicalFile
+
+        if (resolved != base && !resolved.toPath().startsWith(base.toPath())) {
+            throw new ReportException("path ${resolved} is outside allowed directory ${base}")
+        }
+
+        resolved
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/distributor/FilesystemReportDistributor.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/distributor/FilesystemReportDistributor.groovy
@@ -59,6 +59,11 @@ class FilesystemReportDistributor implements ReportDistributor {
     }
 
     @Override
+    boolean isAvailable() {
+        enabled
+    }
+
+    @Override
     void distribute(ReportExecution execution, ReportData reportData, ReportDistributionTarget target) {
         if (!enabled) {
             throw new ReportException("filesystem distributor is disabled")

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/distributor/ReportPayload.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/distributor/ReportPayload.groovy
@@ -1,0 +1,62 @@
+package be.orbinson.aem.groovy.console.reports.distributor
+
+import be.orbinson.aem.groovy.console.reports.ReportExporter
+import be.orbinson.aem.groovy.console.reports.ReportExporterRegistry
+import be.orbinson.aem.groovy.console.reports.ReportException
+import be.orbinson.aem.groovy.console.reports.data.ReportData
+import be.orbinson.aem.groovy.console.reports.model.ReportExecution
+import groovy.transform.PackageScope
+
+import java.text.SimpleDateFormat
+
+/**
+ * A rendered report payload: the exported bytes together with the metadata a distributor needs to attach or write
+ * them (content type, file extension, a default file name).  Shared by all distributors so the export format is
+ * resolved and rendered consistently.
+ */
+@PackageScope
+class ReportPayload {
+
+    private static final String FILE_NAME_TIMESTAMP_FORMAT = "yyyyMMdd-HHmmss"
+
+    final byte[] bytes
+    final String contentType
+    final String fileExtension
+    final String fileName
+
+    private ReportPayload(byte[] bytes, String contentType, String fileExtension, String fileName) {
+        this.bytes = bytes
+        this.contentType = contentType
+        this.fileExtension = fileExtension
+        this.fileName = fileName
+    }
+
+    /**
+     * Render the given report data using the exporter registered for {@code format}.
+     *
+     * @throws ReportException if no exporter is registered for the format
+     */
+    static ReportPayload render(ReportExporterRegistry exporterRegistry, String format, ReportExecution execution,
+                                ReportData reportData) {
+        ReportExporter exporter = exporterRegistry.getExporter(format)
+
+        if (!exporter) {
+            throw new ReportException("no report exporter registered for format : ${format}")
+        }
+
+        def outputStream = new ByteArrayOutputStream()
+
+        exporter.export(reportData, outputStream)
+
+        new ReportPayload(outputStream.toByteArray(), exporter.contentType, exporter.fileExtension,
+                defaultFileName(execution, exporter.fileExtension))
+    }
+
+    private static String defaultFileName(ReportExecution execution, String fileExtension) {
+        def timestampSource = execution.finishedAt ?: execution.startedAt
+        def timestamp = new SimpleDateFormat(FILE_NAME_TIMESTAMP_FORMAT).format(
+                (timestampSource ?: Calendar.instance).time)
+
+        "${execution.reportName}-${timestamp}.${fileExtension}"
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/AppsReportDefinitionListener.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/AppsReportDefinitionListener.groovy
@@ -1,0 +1,71 @@
+package be.orbinson.aem.groovy.console.reports.impl
+
+import be.orbinson.aem.groovy.console.reports.ReportScheduleService
+import groovy.util.logging.Slf4j
+import org.apache.sling.api.resource.observation.ResourceChange
+import org.apache.sling.api.resource.observation.ResourceChangeListener
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Deactivate
+import org.osgi.service.component.annotations.Reference
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+/**
+ * Re-synchronises code-deployed report schedules when the immutable
+ * {@link be.orbinson.aem.groovy.console.reports.constants.ReportsConstants#PATH_APPS_REPORTS_FOLDER} tree changes,
+ * e.g. a content package installing or removing report definitions after startup.  Bursts of change events (a
+ * package install touches many nodes) are debounced into a single reconcile.
+ */
+@Component(property = [
+        "resource.paths=glob:/apps/groovyconsole-reports-definitions/**",
+        "resource.change.types=ADDED",
+        "resource.change.types=CHANGED",
+        "resource.change.types=REMOVED"
+])
+@Slf4j("LOG")
+class AppsReportDefinitionListener implements ResourceChangeListener {
+
+    private static final long DEBOUNCE_MILLIS = 2000
+
+    @Reference
+    private ReportScheduleService scheduleService
+
+    private ScheduledExecutorService executor
+
+    private ScheduledFuture<?> pendingReconcile
+
+    @Activate
+    synchronized void activate() {
+        executor = Executors.newSingleThreadScheduledExecutor()
+    }
+
+    @Deactivate
+    synchronized void deactivate() {
+        executor?.shutdownNow()
+        executor = null
+    }
+
+    @Override
+    synchronized void onChange(List<ResourceChange> changes) {
+        if (executor == null) {
+            return
+        }
+
+        LOG.debug("detected {} code-deployed report definition change(s), scheduling reconcile", changes.size())
+
+        // coalesce event bursts into a single deferred reconcile
+        pendingReconcile?.cancel(false)
+
+        pendingReconcile = executor.schedule({
+            try {
+                scheduleService.reconcileDeployedReports()
+            } catch (Exception e) {
+                LOG.error("error reconciling code-deployed reports after change", e)
+            }
+        } as Runnable, DEBOUNCE_MILLIS, TimeUnit.MILLISECONDS)
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/CronValidator.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/CronValidator.groovy
@@ -1,0 +1,40 @@
+package be.orbinson.aem.groovy.console.reports.impl
+
+/**
+ * Validates cron expressions for scheduled reports before they are persisted or registered with the Sling
+ * scheduler, so an invalid expression is rejected with a clear message instead of failing (or silently not
+ * scheduling) later.
+ *
+ * <p>Sling's scheduler uses the Quartz form: 6 or 7 whitespace-separated fields
+ * (<code>seconds minutes hours day-of-month month day-of-week [year]</code>).  Beyond a structural check this
+ * also rejects sub-minute schedules, which are almost always a mistake for a reporting job and an easy way to
+ * hammer the instance.
+ */
+class CronValidator {
+
+    private CronValidator() {
+    }
+
+    static void validate(String cronExpression) {
+        def expression = cronExpression?.trim()
+
+        if (!expression) {
+            throw new IllegalArgumentException("A cron expression is required for an enabled schedule.")
+        }
+
+        def fields = expression.split(/\s+/)
+
+        if (fields.length < 6 || fields.length > 7) {
+            throw new IllegalArgumentException("Invalid cron expression '${expression}': expected 6 or 7 fields " +
+                    "(seconds minutes hours day-of-month month day-of-week [year]).")
+        }
+
+        // the seconds field must be a fixed value so a report cannot be scheduled to run every second / few seconds
+        def seconds = fields[0]
+
+        if (!(seconds ==~ /\d{1,2}/) || (seconds as int) > 59) {
+            throw new IllegalArgumentException("Invalid cron expression '${expression}': the seconds field must be " +
+                    "a fixed value between 0 and 59; sub-minute schedules are not allowed.")
+        }
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportDistributorRegistry.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportDistributorRegistry.groovy
@@ -1,0 +1,44 @@
+package be.orbinson.aem.groovy.console.reports.impl
+
+import be.orbinson.aem.groovy.console.reports.ReportDistributor
+import be.orbinson.aem.groovy.console.reports.ReportDistributorRegistry
+import groovy.transform.Synchronized
+import groovy.util.logging.Slf4j
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceCardinality
+import org.osgi.service.component.annotations.ReferencePolicy
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+@Component(service = ReportDistributorRegistry, immediate = true)
+@Slf4j("LOG")
+class DefaultReportDistributorRegistry implements ReportDistributorRegistry {
+
+    private volatile List<ReportDistributor> distributors = new CopyOnWriteArrayList<>()
+
+    @Override
+    List<ReportDistributor> getDistributors() {
+        distributors.toSorted { distributor -> distributor.id }
+    }
+
+    @Override
+    ReportDistributor getDistributor(String id) {
+        distributors.find { distributor -> distributor.id == id }
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    @Synchronized
+    void bindReportDistributor(ReportDistributor distributor) {
+        distributors.add(distributor)
+
+        LOG.info("added report distributor : {}", distributor.id)
+    }
+
+    @Synchronized
+    void unbindReportDistributor(ReportDistributor distributor) {
+        distributors.remove(distributor)
+
+        LOG.info("removed report distributor : {}", distributor.id)
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportExecutionService.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportExecutionService.groovy
@@ -394,6 +394,14 @@ class DefaultReportExecutionService implements ReportExecutionService {
     // fail the run — the report itself succeeded.
     private void applyDistributions(ReportExecution execution, ReportData reportData,
                                     List<ReportDistributionTarget> distributionTargets) {
+        // distribution disabled globally (OSGi): the single sink for both the scheduled and manual paths, so this
+        // guard blocks every distribution regardless of how it was triggered
+        if (!reportsConfigurationService.distributionEnabled) {
+            LOG.info("distribution is disabled; skipping {} distribution target(s)", distributionTargets.size())
+
+            return
+        }
+
         def errors = []
 
         distributionTargets.each { target ->

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportExecutionService.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportExecutionService.groovy
@@ -1,11 +1,13 @@
 package be.orbinson.aem.groovy.console.reports.impl
 
 import be.orbinson.aem.groovy.console.GroovyConsoleService
+import be.orbinson.aem.groovy.console.reports.ReportDistributorRegistry
 import be.orbinson.aem.groovy.console.reports.ReportException
 import be.orbinson.aem.groovy.console.reports.ReportExecutionService
 import be.orbinson.aem.groovy.console.reports.ReportResultStore
 import be.orbinson.aem.groovy.console.reports.data.ReportData
 import be.orbinson.aem.groovy.console.reports.model.ReportDefinition
+import be.orbinson.aem.groovy.console.reports.model.ReportDistributionTarget
 import be.orbinson.aem.groovy.console.reports.model.ReportExecution
 import be.orbinson.aem.groovy.console.reports.model.ReportExecutionStatus
 import be.orbinson.aem.groovy.console.reports.model.ReportPreview
@@ -69,6 +71,8 @@ class DefaultReportExecutionService implements ReportExecutionService {
 
     private static final String PROPERTY_SCRIPT = "script"
 
+    private static final String PROPERTY_DISTRIBUTION_ERRORS = "distributionErrors"
+
     @Reference
     private GroovyConsoleService groovyConsoleService
 
@@ -84,9 +88,18 @@ class DefaultReportExecutionService implements ReportExecutionService {
     @Reference
     private ReportsConfigurationService reportsConfigurationService
 
+    @Reference
+    private ReportDistributorRegistry distributorRegistry
+
     @Override
     ReportExecution execute(ReportDefinition reportDefinition, Map<String, String> parameterValues,
                             ResourceResolver resourceResolver) {
+        execute(reportDefinition, parameterValues, resourceResolver, [])
+    }
+
+    @Override
+    ReportExecution execute(ReportDefinition reportDefinition, Map<String, String> parameterValues,
+                            ResourceResolver resourceResolver, List<ReportDistributionTarget> distributionTargets) {
         def coercedValues = ParameterCoercer.coerce(reportDefinition.parameters, parameterValues)
         def script = resolveScript(reportDefinition)
         def userId = resourceResolver.userID
@@ -98,12 +111,13 @@ class DefaultReportExecutionService implements ReportExecutionService {
 
         def asyncResolver = resourceResolver.clone(null)
         def scriptContext = buildReportContext(reportDefinition.name, coercedValues, script, userId, asyncResolver)
+        def targets = distributionTargets ?: []
 
         executionRegistry.start(scriptContext, { RunScriptResponse response, long durationMillis ->
             if (response.exceptionStackTrace) {
                 finishFailed(executionId, response, durationMillis)
             } else {
-                finishSuccess(executionId, response, durationMillis)
+                finishSuccess(executionId, response, durationMillis, targets)
             }
         } as ExecutionCallback)
 
@@ -168,6 +182,27 @@ class DefaultReportExecutionService implements ReportExecutionService {
                 script: script,
                 userId: userId
         )
+    }
+
+    @Override
+    void distribute(String executionId, List<ReportDistributionTarget> distributionTargets) {
+        def execution = getExecution(executionId)
+
+        if (!execution) {
+            throw new ReportException("execution not found: ${executionId}")
+        }
+
+        if (execution.status != ReportExecutionStatus.SUCCESS) {
+            throw new ReportException("only a successful execution can be distributed: ${executionId}")
+        }
+
+        def reportData = resultStore.getData(executionId)
+
+        if (reportData == null) {
+            throw new ReportException("no stored result for execution: ${executionId}")
+        }
+
+        applyDistributions(execution, reportData, distributionTargets ?: [])
     }
 
     @Override
@@ -247,7 +282,8 @@ class DefaultReportExecutionService implements ReportExecutionService {
                 columnCount: properties.get(PROPERTY_COLUMN_COUNT, Long),
                 parameterValues: toParameterValues(properties.get(PROPERTY_PARAMETER_VALUES, String)),
                 output: readOutput(resource),
-                exceptionStackTrace: properties.get(PROPERTY_EXCEPTION_STACK_TRACE, String)
+                exceptionStackTrace: properties.get(PROPERTY_EXCEPTION_STACK_TRACE, String),
+                distributionErrors: (properties.get(PROPERTY_DISTRIBUTION_ERRORS, new String[0]) as List)
         )
     }
 
@@ -292,16 +328,17 @@ class DefaultReportExecutionService implements ReportExecutionService {
         }
     }
 
-    private void finishSuccess(String executionId, RunScriptResponse response, long durationMillis) {
+    private void finishSuccess(String executionId, RunScriptResponse response, long durationMillis,
+                               List<ReportDistributionTarget> distributionTargets) {
         def reportData = ResultParser.parse(response.result)
 
-        withResourceResolver { ResourceResolver resourceResolver ->
+        def distributable = withResourceResolver { ResourceResolver resourceResolver ->
             def resource = getExecutionResource(resourceResolver, executionId)
 
             if (!resource) {
                 LOG.warn("execution {} was removed before it completed; discarding result", executionId)
 
-                return
+                return false
             }
 
             def maxRows = reportsConfigurationService.maxResultRows
@@ -325,7 +362,7 @@ class DefaultReportExecutionService implements ReportExecutionService {
 
                 resourceResolver.commit()
 
-                return
+                return false
             }
 
             def valueMap = resource.adaptTo(ModifiableValueMap)
@@ -344,6 +381,51 @@ class DefaultReportExecutionService implements ReportExecutionService {
             resultStore.save(resourceResolver, resource, reportData)
 
             resourceResolver.commit()
+
+            true
+        }
+
+        if (distributable && distributionTargets) {
+            applyDistributions(getExecution(executionId), reportData, distributionTargets)
+        }
+    }
+
+    // Apply each distribution target to a successful result. Failures are recorded on the execution but never
+    // fail the run — the report itself succeeded.
+    private void applyDistributions(ReportExecution execution, ReportData reportData,
+                                    List<ReportDistributionTarget> distributionTargets) {
+        def errors = []
+
+        distributionTargets.each { target ->
+            try {
+                def distributor = distributorRegistry.getDistributor(target.distributorId)
+
+                if (!distributor) {
+                    errors.add("no distributor registered for '${target.distributorId}'" as String)
+
+                    return
+                }
+
+                distributor.distribute(execution, reportData, target)
+
+                LOG.info("distributed execution {} via {}", execution.id, target.distributorId)
+            } catch (Exception e) {
+                LOG.error("distribution via {} failed for execution {}", target.distributorId, execution.id, e)
+
+                errors.add("${target.distributorId}: ${e.message}" as String)
+            }
+        }
+
+        if (errors) {
+            withResourceResolver { ResourceResolver resourceResolver ->
+                def resource = getExecutionResource(resourceResolver, execution.id)
+
+                if (resource) {
+                    resource.adaptTo(ModifiableValueMap).put(PROPERTY_DISTRIBUTION_ERRORS, errors as String[])
+
+                    resourceResolver.commit()
+                }
+            }
         }
     }
 

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportScheduleService.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportScheduleService.groovy
@@ -1,0 +1,127 @@
+package be.orbinson.aem.groovy.console.reports.impl
+
+import be.orbinson.aem.groovy.console.reports.ReportScheduleService
+import be.orbinson.aem.groovy.console.reports.ReportService
+import be.orbinson.aem.groovy.console.reports.model.ReportDefinition
+import groovy.transform.Synchronized
+import groovy.util.logging.Slf4j
+import org.apache.sling.api.resource.ResourceResolverFactory
+import org.apache.sling.event.jobs.JobManager
+import org.apache.sling.event.jobs.ScheduledJobInfo
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.JOB_PROPERTY_REPORT_NAME
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.JOB_PROPERTY_REPORT_PATH
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.JOB_TOPIC
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.PATH_APPS_REPORTS_FOLDER
+
+/**
+ * Keeps Sling scheduled jobs in sync with report definitions.  Each scheduled report maps to exactly one
+ * scheduled job on {@link be.orbinson.aem.groovy.console.reports.constants.ReportsConstants#JOB_TOPIC}, keyed on
+ * the definition's node path and carrying only that path; the consumer re-reads the (current) definition at run
+ * time.  Definitions authored in the UI live under <code>/conf</code>; definitions deployed in code under the
+ * immutable {@link #PATH_APPS_REPORTS_FOLDER} drop-zone are discovered on activation and whenever that tree
+ * changes.
+ */
+@Component(service = ReportScheduleService, immediate = true)
+@Slf4j("LOG")
+class DefaultReportScheduleService implements ReportScheduleService {
+
+    @Reference
+    private JobManager jobManager
+
+    @Reference
+    private ResourceResolverFactory resourceResolverFactory
+
+    @Reference
+    private ReportService reportService
+
+    @Activate
+    void activate() {
+        reconcileDeployedReports()
+    }
+
+    @Override
+    @Synchronized
+    void reconcile(ReportDefinition reportDefinition) {
+        unschedule(reportDefinition.path)
+
+        def schedule = reportDefinition.schedule
+
+        if (!schedule?.enabled || !schedule.cronExpression?.trim()) {
+            return
+        }
+
+        try {
+            CronValidator.validate(schedule.cronExpression)
+        } catch (IllegalArgumentException e) {
+            LOG.error("not scheduling report {}: {}", reportDefinition.path, e.message)
+
+            return
+        }
+
+        def errors = []
+
+        def result = jobManager.createJob(JOB_TOPIC)
+                .properties([
+                        (JOB_PROPERTY_REPORT_PATH): reportDefinition.path,
+                        (JOB_PROPERTY_REPORT_NAME): reportDefinition.name
+                ] as Map<String, Object>)
+                .schedule()
+                .cron(schedule.cronExpression)
+                .add(errors)
+
+        if (result) {
+            LOG.info("scheduled report {} with cron {}", reportDefinition.path, schedule.cronExpression)
+        } else {
+            LOG.error("failed to schedule report {} with cron {}: {}", reportDefinition.path,
+                    schedule.cronExpression, errors.join("; "))
+        }
+    }
+
+    @Override
+    @Synchronized
+    void unschedule(String reportPath) {
+        scheduledJobsFor(reportPath).each { scheduledJob ->
+            scheduledJob.unschedule()
+
+            LOG.info("unscheduled report {}", reportPath)
+        }
+    }
+
+    @Override
+    @Synchronized
+    void reconcileDeployedReports() {
+        try {
+            resourceResolverFactory.getServiceResourceResolver(null).withCloseable { resolver ->
+                def deployed = reportService.findReports(resolver, PATH_APPS_REPORTS_FOLDER)
+                def deployedPaths = deployed*.path as Set
+
+                // drop jobs for code-deployed definitions that no longer exist (e.g. uninstalled package)
+                jobManager.getScheduledJobs(JOB_TOPIC, 0, null).each { scheduledJob ->
+                    def path = scheduledJob.jobProperties[JOB_PROPERTY_REPORT_PATH] as String
+
+                    if (path?.startsWith("$PATH_APPS_REPORTS_FOLDER/") && !deployedPaths.contains(path)) {
+                        scheduledJob.unschedule()
+
+                        LOG.info("unscheduled removed code-deployed report {}", path)
+                    }
+                }
+
+                deployed.each { definition -> reconcile(definition) }
+
+                LOG.info("reconciled {} code-deployed report definition(s) under {}", deployed.size(),
+                        PATH_APPS_REPORTS_FOLDER)
+            }
+        } catch (Exception e) {
+            LOG.error("error reconciling code-deployed reports under {}", PATH_APPS_REPORTS_FOLDER, e)
+        }
+    }
+
+    private Collection<ScheduledJobInfo> scheduledJobsFor(String reportPath) {
+        jobManager.getScheduledJobs(JOB_TOPIC, 0, null)
+                .findAll { scheduledJob -> scheduledJob.jobProperties[JOB_PROPERTY_REPORT_PATH] == reportPath }
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportScheduleService.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportScheduleService.groovy
@@ -38,6 +38,9 @@ class DefaultReportScheduleService implements ReportScheduleService {
     @Reference
     private ReportService reportService
 
+    @Reference
+    private ReportsConfigurationService reportsConfigurationService
+
     @Activate
     void activate() {
         reconcileDeployedReports()
@@ -47,6 +50,12 @@ class DefaultReportScheduleService implements ReportScheduleService {
     @Synchronized
     void reconcile(ReportDefinition reportDefinition) {
         unschedule(reportDefinition.path)
+
+        // scheduling disabled globally (OSGi): never register a job; the unschedule above also drops any that
+        // survived from when it was enabled
+        if (!reportsConfigurationService.schedulingEnabled) {
+            return
+        }
 
         def schedule = reportDefinition.schedule
 
@@ -94,6 +103,19 @@ class DefaultReportScheduleService implements ReportScheduleService {
     @Override
     @Synchronized
     void reconcileDeployedReports() {
+        // scheduling disabled globally (OSGi): drop every report job (UI- and code-authored alike) and stop
+        if (!reportsConfigurationService.schedulingEnabled) {
+            def scheduledJobs = jobManager.getScheduledJobs(JOB_TOPIC, 0, null)
+
+            scheduledJobs.each { scheduledJob -> scheduledJob.unschedule() }
+
+            if (scheduledJobs) {
+                LOG.info("scheduling disabled; unscheduled {} report job(s)", scheduledJobs.size())
+            }
+
+            return
+        }
+
         try {
             resourceResolverFactory.getServiceResourceResolver(null).withCloseable { resolver ->
                 def deployed = reportService.findReports(resolver, PATH_APPS_REPORTS_FOLDER)

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportService.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportService.groovy
@@ -442,7 +442,8 @@ class DefaultReportService implements ReportService {
                 cronExpression: properties.get(PROPERTY_CRON_EXPRESSION, String),
                 runAs: properties.get(PROPERTY_RUN_AS, String),
                 scheduledBy: properties.get(PROPERTY_SCHEDULED_BY, String),
-                parameterValues: toStringMap(properties.get(PROPERTY_PARAMETER_VALUES, String))
+                // preserve arrays for `multiple` parameters (do not flatten to String)
+                parameterValues: toObjectMap(properties.get(PROPERTY_PARAMETER_VALUES, String))
         )
     }
 

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportService.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportService.groovy
@@ -3,8 +3,12 @@ package be.orbinson.aem.groovy.console.reports.impl
 import be.orbinson.aem.groovy.console.reports.ReportException
 import be.orbinson.aem.groovy.console.reports.ReportService
 import be.orbinson.aem.groovy.console.reports.model.ReportDefinition
+import be.orbinson.aem.groovy.console.reports.model.ReportDistributionTarget
 import be.orbinson.aem.groovy.console.reports.model.ReportParameter
 import be.orbinson.aem.groovy.console.reports.model.ReportParameterType
+import be.orbinson.aem.groovy.console.reports.model.ReportSchedule
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
 import groovy.util.logging.Slf4j
 import org.apache.jackrabbit.JcrConstants
 import org.apache.sling.api.resource.ModifiableValueMap
@@ -18,9 +22,11 @@ import org.osgi.service.component.annotations.Component
 import javax.jcr.Session
 
 import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.CHARSET
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.DISTRIBUTIONS_NODE_NAME
 import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.PARAMETERS_NODE_NAME
 import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.PATH_REPORTS_FOLDER
 import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.RESOURCE_TYPE_DEFINITION
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.SCHEDULE_NODE_NAME
 
 /**
  * Report definition CRUD backed by the requesting user's resolver, so JCR access control alone governs who can
@@ -51,6 +57,24 @@ class DefaultReportService implements ReportService {
 
     private static final String PROPERTY_LAST_MODIFIED_BY = "lastModifiedBy"
 
+    private static final String PROPERTY_ENABLED = "enabled"
+
+    private static final String PROPERTY_CRON_EXPRESSION = "cronExpression"
+
+    private static final String PROPERTY_RUN_AS = "runAs"
+
+    private static final String PROPERTY_SCHEDULED_BY = "scheduledBy"
+
+    private static final String PROPERTY_PARAMETER_VALUES = "parameterValues"
+
+    private static final String PROPERTY_DISTRIBUTOR_ID = "distributorId"
+
+    private static final String PROPERTY_FORMAT = "format"
+
+    private static final String PROPERTY_CONFIG = "config"
+
+    private static final String DISTRIBUTION_NODE_PREFIX = "target"
+
     @Override
     List<ReportDefinition> getReports(ResourceResolver resourceResolver) {
         def reportsFolder = resourceResolver.getResource(PATH_REPORTS_FOLDER)
@@ -70,6 +94,31 @@ class DefaultReportService implements ReportService {
         def resource = getReportResource(resourceResolver, name)
 
         resource ? toReportDefinition(resource) : null
+    }
+
+    @Override
+    ReportDefinition getReportAtPath(ResourceResolver resourceResolver, String path) {
+        if (!path) {
+            return null
+        }
+
+        def resource = resourceResolver.getResource(path)
+
+        resource && isReportDefinition(resource) ? toReportDefinition(resource) : null
+    }
+
+    @Override
+    List<ReportDefinition> findReports(ResourceResolver resourceResolver, String basePath) {
+        def base = basePath ? resourceResolver.getResource(basePath) : null
+
+        if (!base) {
+            return []
+        }
+
+        def definitions = []
+        collectDefinitions(base, definitions)
+
+        definitions.sort { definition -> definition.path }
     }
 
     @Override
@@ -102,6 +151,8 @@ class DefaultReportService implements ReportService {
 
             saveScript(resourceResolver, resource, reportDefinition.script)
             saveParameters(resourceResolver, resource, reportDefinition.parameters)
+            saveSchedule(resourceResolver, resource, reportDefinition.schedule, userId)
+            saveDistributions(resourceResolver, resource, reportDefinition.distributions)
 
             resourceResolver.commit()
 
@@ -195,6 +246,11 @@ class DefaultReportService implements ReportService {
                         "Parameter names are required and may only contain letters, digits, '-' and '_'.")
             }
         }
+
+        // reject a bad cron before anything is written, so an enabled schedule always has a runnable expression
+        if (reportDefinition.schedule?.enabled) {
+            CronValidator.validate(reportDefinition.schedule.cronExpression)
+        }
     }
 
     private static void putOrRemove(ModifiableValueMap valueMap, String name, Object value) {
@@ -266,6 +322,127 @@ class DefaultReportService implements ReportService {
         }
     }
 
+    // Persist the schedule under a child node. Sets scheduledBy server-side and enforces the run-as gate: a
+    // non-self runAs is only accepted when the requesting user is permitted to impersonate it.
+    private static void saveSchedule(ResourceResolver resourceResolver, Resource reportResource,
+                                     ReportSchedule schedule, String userId) {
+        def existing = reportResource.getChild(SCHEDULE_NODE_NAME)
+
+        if (existing) {
+            resourceResolver.delete(existing)
+        }
+
+        if (!schedule) {
+            return
+        }
+
+        // schedules saved through the service (the UI/API path) always run as their author: runAs is forced to
+        // the requesting user, so a user can only ever schedule a report to run as themselves. (Reports deployed
+        // in code bypass this and may leave runAs blank to run as the executor service user.)
+        schedule.scheduledBy = userId
+        schedule.runAs = userId
+
+        resourceResolver.create(reportResource, SCHEDULE_NODE_NAME, [
+                (JcrConstants.JCR_PRIMARYTYPE): JcrConstants.NT_UNSTRUCTURED,
+                (PROPERTY_ENABLED)            : schedule.enabled,
+                (PROPERTY_CRON_EXPRESSION)    : schedule.cronExpression ?: "",
+                (PROPERTY_RUN_AS)             : schedule.runAs,
+                (PROPERTY_SCHEDULED_BY)       : schedule.scheduledBy,
+                (PROPERTY_PARAMETER_VALUES)   : new JsonBuilder(schedule.parameterValues ?: [:]).toString()
+        ] as Map<String, Object>)
+    }
+
+    private static void saveDistributions(ResourceResolver resourceResolver, Resource reportResource,
+                                          List<ReportDistributionTarget> distributions) {
+        def existing = reportResource.getChild(DISTRIBUTIONS_NODE_NAME)
+
+        if (existing) {
+            resourceResolver.delete(existing)
+        }
+
+        if (!distributions) {
+            return
+        }
+
+        def distributionsResource = resourceResolver.create(reportResource, DISTRIBUTIONS_NODE_NAME,
+                [(JcrConstants.JCR_PRIMARYTYPE): JcrConstants.NT_UNSTRUCTURED] as Map<String, Object>)
+
+        distributions.eachWithIndex { target, index ->
+            resourceResolver.create(distributionsResource, "$DISTRIBUTION_NODE_PREFIX$index", [
+                    (JcrConstants.JCR_PRIMARYTYPE): JcrConstants.NT_UNSTRUCTURED,
+                    (PROPERTY_DISTRIBUTOR_ID)     : target.distributorId,
+                    (PROPERTY_FORMAT)             : target.format,
+                    (PROPERTY_CONFIG)             : new JsonBuilder(target.config ?: [:]).toString()
+            ] as Map<String, Object>)
+        }
+    }
+
+    private static ReportSchedule readSchedule(Resource reportResource) {
+        def scheduleResource = reportResource.getChild(SCHEDULE_NODE_NAME)
+
+        if (!scheduleResource) {
+            return null
+        }
+
+        def properties = scheduleResource.valueMap
+
+        new ReportSchedule(
+                enabled: properties.get(PROPERTY_ENABLED, false),
+                cronExpression: properties.get(PROPERTY_CRON_EXPRESSION, String),
+                runAs: properties.get(PROPERTY_RUN_AS, String),
+                scheduledBy: properties.get(PROPERTY_SCHEDULED_BY, String),
+                parameterValues: toStringMap(properties.get(PROPERTY_PARAMETER_VALUES, String))
+        )
+    }
+
+    private static List<ReportDistributionTarget> readDistributions(Resource reportResource) {
+        def distributionsResource = reportResource.getChild(DISTRIBUTIONS_NODE_NAME)
+
+        if (!distributionsResource) {
+            return []
+        }
+
+        distributionsResource.listChildren()
+                .findAll { child -> child.name.startsWith(DISTRIBUTION_NODE_PREFIX) }
+                .sort { child -> child.name }
+                .collect { child ->
+                    def properties = child.valueMap
+
+                    new ReportDistributionTarget(
+                            distributorId: properties.get(PROPERTY_DISTRIBUTOR_ID, String),
+                            format: properties.get(PROPERTY_FORMAT, String),
+                            config: toObjectMap(properties.get(PROPERTY_CONFIG, String))
+                    )
+                }
+    }
+
+    private static Map<String, String> toStringMap(String json) {
+        toObjectMap(json).collectEntries { key, value -> [(key): value as String] } as Map<String, String>
+    }
+
+    private static Map<String, Object> toObjectMap(String json) {
+        if (!json) {
+            return [:]
+        }
+
+        try {
+            new JsonSlurper().parseText(json) as Map<String, Object>
+        } catch (Exception ignored) {
+            [:]
+        }
+    }
+
+    // depth-first collect report definitions under a folder, not descending into a definition's own child nodes
+    private static void collectDefinitions(Resource resource, List<ReportDefinition> definitions) {
+        resource.listChildren().each { child ->
+            if (isReportDefinition(child)) {
+                definitions.add(toReportDefinition(child))
+            } else {
+                collectDefinitions(child, definitions)
+            }
+        }
+    }
+
     private static boolean isReportDefinition(Resource resource) {
         resource.isResourceType(RESOURCE_TYPE_DEFINITION)
     }
@@ -299,12 +476,15 @@ class DefaultReportService implements ReportService {
 
         new ReportDefinition(
                 name: resource.name,
+                path: resource.path,
                 title: properties.get(PROPERTY_TITLE, resource.name),
                 description: properties.get(PROPERTY_DESCRIPTION, String),
                 category: properties.get(PROPERTY_CATEGORY, String),
                 script: readScript(resource),
                 pageSize: properties.get(PROPERTY_PAGE_SIZE, Integer),
                 parameters: toParameters(resource),
+                schedule: readSchedule(resource),
+                distributions: readDistributions(resource),
                 created: properties.get(JcrConstants.JCR_CREATED, Calendar),
                 createdBy: properties.get(PROPERTY_CREATED_BY, String),
                 lastModified: properties.get(PROPERTY_LAST_MODIFIED, Calendar),

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportsConfigurationService.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportsConfigurationService.groovy
@@ -14,12 +14,18 @@ class DefaultReportsConfigurationService implements ReportsConfigurationService 
 
     private int maxResultRows
 
+    private boolean schedulingEnabled
+
+    private boolean distributionEnabled
+
     @Activate
     @Modified
     @Synchronized
     void activate(ReportsConfigurationProperties properties) {
         defaultPageSize = properties.defaultPageSize()
         maxResultRows = properties.maxResultRows()
+        schedulingEnabled = properties.schedulingEnabled()
+        distributionEnabled = properties.distributionEnabled()
     }
 
     @Override
@@ -30,5 +36,15 @@ class DefaultReportsConfigurationService implements ReportsConfigurationService 
     @Override
     int getMaxResultRows() {
         maxResultRows
+    }
+
+    @Override
+    boolean isSchedulingEnabled() {
+        schedulingEnabled
+    }
+
+    @Override
+    boolean isDistributionEnabled() {
+        distributionEnabled
     }
 }

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/ReportImpersonation.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/ReportImpersonation.groovy
@@ -1,0 +1,107 @@
+package be.orbinson.aem.groovy.console.reports.impl
+
+import be.orbinson.aem.groovy.console.reports.ReportException
+import groovy.util.logging.Slf4j
+import org.apache.jackrabbit.api.JackrabbitSession
+import org.apache.jackrabbit.api.security.user.Authorizable
+import org.apache.jackrabbit.api.security.user.User
+import org.apache.sling.api.resource.LoginException
+import org.apache.sling.api.resource.ResourceResolver
+import org.apache.sling.api.resource.ResourceResolverFactory
+
+import javax.jcr.Session
+
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.EXECUTOR_SUBSERVICE
+
+/**
+ * Run-as handling for scheduled reports.
+ *
+ * <p>Scheduled reports execute under the dedicated <em>executor</em> service user (a separate identity from the
+ * bookkeeping service user, with its own read ACLs — see the reports repoinit). A report deployed in code with no
+ * {@code runAs} simply runs as that executor. A report scheduled through the UI always names its own author as
+ * {@code runAs}; the executor then impersonates that user so the run is bounded by exactly the author's
+ * permissions.
+ *
+ * <p>That impersonation is enabled by {@link #grantSelfImpersonation}, called when the schedule is saved: a user
+ * may grant a system user impersonation over <em>their own</em> account (verified on Oak), so no privileged
+ * user-administration service is needed and a user can only ever enable running as themselves.
+ */
+@Slf4j("LOG")
+class ReportImpersonation {
+
+    private ReportImpersonation() {
+    }
+
+    /** Open a resolver for the executor service user (the scheduled-report execution identity). */
+    static ResourceResolver executorResolver(ResourceResolverFactory resourceResolverFactory) {
+        resourceResolverFactory.getServiceResourceResolver(
+                [(ResourceResolverFactory.SUBSERVICE): EXECUTOR_SUBSERVICE] as Map<String, Object>)
+    }
+
+    /**
+     * Resolve the resolver a scheduled report should run under: the executor itself when no {@code runAs} is
+     * configured, otherwise the executor impersonating {@code runAs}.  A distinct impersonated resolver is owned
+     * by the caller and must be closed (see {@link #isImpersonated}).
+     *
+     * @throws ReportException when {@code runAs} is set but the executor may not impersonate it (e.g. the
+     *         self-grant is missing)
+     */
+    static ResourceResolver runResolver(ResourceResolver executorResolver, String runAs) {
+        if (!runAs?.trim() || runAs == executorResolver.userID) {
+            return executorResolver
+        }
+
+        try {
+            executorResolver.clone([(ResourceResolverFactory.USER_IMPERSONATION): runAs] as Map<String, Object>)
+        } catch (LoginException e) {
+            throw new ReportException("the reports executor is not permitted to run reports as ${runAs}; " +
+                    "the schedule must be re-saved by that user to grant impersonation", e)
+        }
+    }
+
+    /** Whether {@code runResolver} produced a distinct impersonated resolver the caller must close. */
+    static boolean isImpersonated(ResourceResolver executorResolver, ResourceResolver runResolver) {
+        !executorResolver.is(runResolver)
+    }
+
+    /**
+     * Grant the executor system user impersonation over the resolver's own user, so scheduled runs can later run
+     * as that user.  Idempotent and self-scoped: a user can only ever grant impersonation over themselves, so
+     * this cannot be used to run as anyone else.  Best-effort — a failure is logged, not thrown, so saving a
+     * report never fails on impersonation setup (the scheduled run fails closed later if the grant is missing).
+     *
+     * @param resourceResolver the requesting (schedule author's) resolver
+     * @param executorUserId the executor system user id
+     */
+    static void grantSelfImpersonation(ResourceResolver resourceResolver, String executorUserId) {
+        def session = resourceResolver.adaptTo(Session)
+
+        if (!(session instanceof JackrabbitSession)) {
+            LOG.warn("cannot grant executor impersonation: no Jackrabbit session available")
+
+            return
+        }
+
+        try {
+            def userManager = ((JackrabbitSession) session).userManager
+            Authorizable executor = userManager.getAuthorizable(executorUserId)
+            Authorizable self = userManager.getAuthorizable(resourceResolver.userID)
+
+            if (executor == null || !(self instanceof User)) {
+                LOG.warn("cannot grant executor impersonation: executor '{}' or user '{}' not found",
+                        executorUserId, resourceResolver.userID)
+
+                return
+            }
+
+            if (((User) self).impersonation.grantImpersonation(executor.principal)) {
+                session.save()
+
+                LOG.info("granted executor {} impersonation over {}", executorUserId, resourceResolver.userID)
+            }
+        } catch (Exception e) {
+            LOG.warn("could not grant executor impersonation over {}; scheduled runs as this user will fail " +
+                    "until impersonation is configured", resourceResolver.userID, e)
+        }
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/ReportScheduledJobConsumer.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/ReportScheduledJobConsumer.groovy
@@ -30,10 +30,21 @@ class ReportScheduledJobConsumer implements JobConsumer {
     @Reference
     private ReportExecutionService reportExecutionService
 
+    @Reference
+    private ReportsConfigurationService reportsConfigurationService
+
     @Override
     JobConsumer.JobResult process(Job job) {
         def reportPath = job.getProperty(JOB_PROPERTY_REPORT_PATH, String)
         def reportName = job.getProperty(JOB_PROPERTY_REPORT_NAME, String)
+
+        // scheduling disabled globally (OSGi): skip any job that still fires (jobs are unregistered on startup,
+        // but a job could be mid-flight when the config is toggled)
+        if (!reportsConfigurationService.schedulingEnabled) {
+            LOG.info("scheduling is disabled; skipping scheduled report {}", reportName)
+
+            return JobConsumer.JobResult.OK
+        }
 
         if (!reportPath) {
             LOG.error("scheduled report job has no report path; cancelling")

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/ReportScheduledJobConsumer.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/ReportScheduledJobConsumer.groovy
@@ -1,0 +1,90 @@
+package be.orbinson.aem.groovy.console.reports.impl
+
+import be.orbinson.aem.groovy.console.reports.ReportExecutionService
+import be.orbinson.aem.groovy.console.reports.ReportService
+import groovy.util.logging.Slf4j
+import org.apache.sling.api.resource.ResourceResolverFactory
+import org.apache.sling.event.jobs.Job
+import org.apache.sling.event.jobs.consumer.JobConsumer
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.JOB_PROPERTY_REPORT_NAME
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.JOB_PROPERTY_REPORT_PATH
+
+/**
+ * Runs a scheduled report when its cron job fires.  Reads the current definition, impersonates the authorized
+ * run-as user (see {@link ReportImpersonation}) and starts the execution with the report's configured
+ * distributions applied on completion.
+ */
+@Component(service = JobConsumer, property = ["job.topics=groovyconsole/reports/job"])
+@Slf4j("LOG")
+class ReportScheduledJobConsumer implements JobConsumer {
+
+    @Reference
+    private ResourceResolverFactory resourceResolverFactory
+
+    @Reference
+    private ReportService reportService
+
+    @Reference
+    private ReportExecutionService reportExecutionService
+
+    @Override
+    JobConsumer.JobResult process(Job job) {
+        def reportPath = job.getProperty(JOB_PROPERTY_REPORT_PATH, String)
+        def reportName = job.getProperty(JOB_PROPERTY_REPORT_NAME, String)
+
+        if (!reportPath) {
+            LOG.error("scheduled report job has no report path; cancelling")
+
+            return JobConsumer.JobResult.CANCEL
+        }
+
+        try {
+            resourceResolverFactory.getServiceResourceResolver(null).withCloseable { serviceResolver ->
+                def definition = reportService.getReportAtPath(serviceResolver, reportPath)
+
+                if (!definition) {
+                    LOG.warn("scheduled report {} no longer exists; cancelling", reportPath)
+
+                    return JobConsumer.JobResult.CANCEL
+                }
+
+                def schedule = definition.schedule
+
+                if (!schedule?.enabled) {
+                    LOG.info("scheduled report {} is no longer enabled; skipping", reportName)
+
+                    return JobConsumer.JobResult.OK
+                }
+
+                // run under the executor service user; a configured runAs (UI schedules always set their author)
+                // is impersonated so the run is bounded by that user's own permissions
+                def executorResolver = ReportImpersonation.executorResolver(resourceResolverFactory)
+
+                executorResolver.withCloseable {
+                    def runResolver = ReportImpersonation.runResolver(executorResolver, schedule.runAs)
+                    def runAsUserId = runResolver.userID
+
+                    try {
+                        reportExecutionService.execute(definition, schedule.parameterValues, runResolver,
+                                definition.distributions)
+                    } finally {
+                        if (ReportImpersonation.isImpersonated(executorResolver, runResolver)) {
+                            runResolver.close()
+                        }
+                    }
+
+                    LOG.info("started scheduled execution of report {} as {}", reportName, runAsUserId)
+                }
+
+                JobConsumer.JobResult.OK
+            }
+        } catch (Exception e) {
+            LOG.error("error running scheduled report {}", reportName, e)
+
+            JobConsumer.JobResult.FAILED
+        }
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/ReportsConfigurationService.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/impl/ReportsConfigurationService.groovy
@@ -9,4 +9,10 @@ interface ReportsConfigurationService {
 
     /** Maximum result rows persisted per execution; 0 means unlimited. */
     int getMaxResultRows()
+
+    /** Whether reports may run on a schedule. */
+    boolean isSchedulingEnabled()
+
+    /** Whether report results may be distributed (scheduled or manual). */
+    boolean isDistributionEnabled()
 }

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportDistributeServlet.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportDistributeServlet.groovy
@@ -1,0 +1,87 @@
+package be.orbinson.aem.groovy.console.reports.servlets
+
+import be.orbinson.aem.groovy.console.configuration.ConfigurationService
+import be.orbinson.aem.groovy.console.reports.ReportException
+import be.orbinson.aem.groovy.console.reports.ReportExecutionService
+import be.orbinson.aem.groovy.console.reports.ReportService
+import groovy.util.logging.Slf4j
+import org.apache.sling.api.SlingHttpServletRequest
+import org.apache.sling.api.SlingHttpServletResponse
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+
+import javax.servlet.Servlet
+import javax.servlet.ServletException
+
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.PARAMETER_EXECUTION_ID
+import static javax.servlet.http.HttpServletResponse.*
+
+/**
+ * Distribute the result of an already-completed execution on demand.  Distribution can send report data to
+ * external destinations, so it requires manage access to the execution's report.
+ *
+ * <code>POST /bin/groovyconsole/reports/distribute</code> with JSON body
+ * <code>{"executionId": "...", "targets": [{"distributorId": "email", "format": "csv", "config": {...}}]}</code>.
+ */
+@Component(service = Servlet, immediate = true, property = [
+        "sling.servlet.paths=/bin/groovyconsole/reports/distribute"
+])
+@Slf4j("LOG")
+class ReportDistributeServlet extends AbstractReportsServlet {
+
+    @Reference
+    private ReportService reportService
+
+    @Reference
+    private ReportExecutionService executionService
+
+    @Reference
+    private ConfigurationService configurationService
+
+    @Override
+    protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        def body = readJsonBody(request)
+        def executionId = body?.get(PARAMETER_EXECUTION_ID) as String
+
+        if (!executionId) {
+            writeError(response, SC_BAD_REQUEST, "A JSON body with an 'executionId' property is required.")
+
+            return
+        }
+
+        def execution = executionService.getExecution(executionId)
+
+        if (!execution) {
+            writeError(response, SC_NOT_FOUND, "Execution not found: $executionId")
+
+            return
+        }
+
+        if (!canManageExecution(request, execution, reportService, configurationService)) {
+            writeError(response, SC_FORBIDDEN, "Not allowed to distribute this execution.")
+
+            return
+        }
+
+        def targets = (body["targets"] as List ?: []).collect { target ->
+            ReportsServlet.distributionFromBody(target as Map)
+        }
+
+        if (!targets) {
+            writeError(response, SC_BAD_REQUEST, "At least one distribution target is required.")
+
+            return
+        }
+
+        try {
+            executionService.distribute(executionId, targets)
+
+            writeJsonResponse(response, ReportJsonMapper.execution(executionService.getExecution(executionId)))
+        } catch (ReportException e) {
+            LOG.warn("error distributing execution : {}", executionId, e)
+
+            writeError(response, SC_INTERNAL_SERVER_ERROR, e.message)
+        }
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportDistributeServlet.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportDistributeServlet.groovy
@@ -4,6 +4,7 @@ import be.orbinson.aem.groovy.console.configuration.ConfigurationService
 import be.orbinson.aem.groovy.console.reports.ReportException
 import be.orbinson.aem.groovy.console.reports.ReportExecutionService
 import be.orbinson.aem.groovy.console.reports.ReportService
+import be.orbinson.aem.groovy.console.reports.impl.ReportsConfigurationService
 import groovy.util.logging.Slf4j
 import org.apache.sling.api.SlingHttpServletRequest
 import org.apache.sling.api.SlingHttpServletResponse
@@ -38,9 +39,18 @@ class ReportDistributeServlet extends AbstractReportsServlet {
     @Reference
     private ConfigurationService configurationService
 
+    @Reference
+    private ReportsConfigurationService reportsConfigurationService
+
     @Override
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
+        if (!reportsConfigurationService.distributionEnabled) {
+            writeError(response, SC_SERVICE_UNAVAILABLE, "Report distribution is disabled.")
+
+            return
+        }
+
         def body = readJsonBody(request)
         def executionId = body?.get(PARAMETER_EXECUTION_ID) as String
 

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportDistributorsServlet.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportDistributorsServlet.groovy
@@ -33,8 +33,9 @@ class ReportDistributorsServlet extends AbstractReportsServlet {
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
         writeJsonResponse(response, [
-                distributors: distributorRegistry.distributors.collect { distributor ->
-                    ReportJsonMapper.distributor(distributor)
+                // only list usable distributors, so authors are never offered a disabled/unconfigured destination
+                distributors: distributorRegistry.distributors.findAll { distributor -> distributor.available }.collect {
+                    distributor -> ReportJsonMapper.distributor(distributor)
                 },
                 formats     : exporterRegistry.exporters.collect { exporter -> ReportJsonMapper.format(exporter) }
         ])

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportDistributorsServlet.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportDistributorsServlet.groovy
@@ -1,0 +1,42 @@
+package be.orbinson.aem.groovy.console.reports.servlets
+
+import be.orbinson.aem.groovy.console.reports.ReportDistributorRegistry
+import be.orbinson.aem.groovy.console.reports.ReportExporterRegistry
+import groovy.util.logging.Slf4j
+import org.apache.sling.api.SlingHttpServletRequest
+import org.apache.sling.api.SlingHttpServletResponse
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+
+import javax.servlet.Servlet
+import javax.servlet.ServletException
+
+/**
+ * Available distributors and export formats, discovered from the registered services.  Used by the report editor
+ * to offer distribution targets.
+ *
+ * <code>GET /bin/groovyconsole/reports/distributors.json</code>
+ */
+@Component(service = Servlet, immediate = true, property = [
+        "sling.servlet.paths=/bin/groovyconsole/reports/distributors"
+])
+@Slf4j("LOG")
+class ReportDistributorsServlet extends AbstractReportsServlet {
+
+    @Reference
+    private ReportDistributorRegistry distributorRegistry
+
+    @Reference
+    private ReportExporterRegistry exporterRegistry
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        writeJsonResponse(response, [
+                distributors: distributorRegistry.distributors.collect { distributor ->
+                    ReportJsonMapper.distributor(distributor)
+                },
+                formats     : exporterRegistry.exporters.collect { exporter -> ReportJsonMapper.format(exporter) }
+        ])
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportJsonMapper.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportJsonMapper.groovy
@@ -1,11 +1,14 @@
 package be.orbinson.aem.groovy.console.reports.servlets
 
+import be.orbinson.aem.groovy.console.reports.ReportDistributor
 import be.orbinson.aem.groovy.console.reports.ReportExporter
 import be.orbinson.aem.groovy.console.reports.model.ReportDefinition
+import be.orbinson.aem.groovy.console.reports.model.ReportDistributionTarget
 import be.orbinson.aem.groovy.console.reports.model.ReportExecution
 import be.orbinson.aem.groovy.console.reports.model.ReportParameter
 import be.orbinson.aem.groovy.console.reports.model.ReportPreview
 import be.orbinson.aem.groovy.console.reports.model.ReportResultPage
+import be.orbinson.aem.groovy.console.reports.model.ReportSchedule
 
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -36,12 +39,43 @@ class ReportJsonMapper {
                 script        : definition.script,
                 pageSize      : definition.pageSize,
                 parameters    : definition.parameters.collect { reportParameter -> parameter(reportParameter) },
+                schedule      : schedule(definition.schedule),
+                distributions : definition.distributions.collect { target -> distributionTarget(target) },
                 created       : formatDate(definition.created),
                 createdBy     : definition.createdBy,
                 lastModified  : formatDate(definition.lastModified),
                 lastModifiedBy: definition.lastModifiedBy,
                 canEdit       : canEdit,
                 exportFormats : exporters.collect { exporter -> format(exporter) }
+        ]
+    }
+
+    static Map schedule(ReportSchedule schedule) {
+        if (schedule == null) {
+            return null
+        }
+
+        [
+                enabled        : schedule.enabled,
+                cronExpression : schedule.cronExpression,
+                runAs          : schedule.runAs,
+                scheduledBy    : schedule.scheduledBy,
+                parameterValues: schedule.parameterValues
+        ]
+    }
+
+    static Map distributionTarget(ReportDistributionTarget target) {
+        [
+                distributorId: target.distributorId,
+                format       : target.format,
+                config       : target.config
+        ]
+    }
+
+    static Map distributor(ReportDistributor distributor) {
+        [
+                id  : distributor.id,
+                name: distributor.name
         ]
     }
 
@@ -73,7 +107,8 @@ class ReportJsonMapper {
                 columnCount        : execution.columnCount,
                 parameterValues    : execution.parameterValues,
                 output             : execution.output,
-                exceptionStackTrace: execution.exceptionStackTrace
+                exceptionStackTrace: execution.exceptionStackTrace,
+                distributionErrors : execution.distributionErrors
         ]
     }
 

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportsConfigServlet.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportsConfigServlet.groovy
@@ -1,0 +1,36 @@
+package be.orbinson.aem.groovy.console.reports.servlets
+
+import be.orbinson.aem.groovy.console.reports.impl.ReportsConfigurationService
+import groovy.util.logging.Slf4j
+import org.apache.sling.api.SlingHttpServletRequest
+import org.apache.sling.api.SlingHttpServletResponse
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+
+import javax.servlet.Servlet
+import javax.servlet.ServletException
+
+/**
+ * Global reports feature flags (OSGi), so the UI can hide the scheduling / distribution sections when an
+ * operator has turned those features off.
+ *
+ * <code>GET /bin/groovyconsole/reports/config.json</code>
+ */
+@Component(service = Servlet, immediate = true, property = [
+        "sling.servlet.paths=/bin/groovyconsole/reports/config"
+])
+@Slf4j("LOG")
+class ReportsConfigServlet extends AbstractReportsServlet {
+
+    @Reference
+    private ReportsConfigurationService reportsConfigurationService
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        writeJsonResponse(response, [
+                schedulingEnabled  : reportsConfigurationService.schedulingEnabled,
+                distributionEnabled: reportsConfigurationService.distributionEnabled
+        ])
+    }
+}

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportsServlet.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportsServlet.groovy
@@ -200,9 +200,10 @@ class ReportsServlet extends AbstractReportsServlet {
         new ReportSchedule(
                 enabled: Boolean.TRUE == schedule["enabled"],
                 cronExpression: schedule["cronExpression"] as String,
+                // keep each value as sent: a String, or a List of Strings for a `multiple` parameter
                 parameterValues: (schedule["parameterValues"] as Map ?: [:]).collectEntries { key, value ->
-                    [(key as String): value == null ? null : value as String]
-                } as Map<String, String>
+                    [(key as String): value instanceof List ? value.collect { it as String } : (value == null ? null : value as String)]
+                } as Map<String, Object>
         )
     }
 

--- a/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportsServlet.groovy
+++ b/extensions/reports/bundle/src/main/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportsServlet.groovy
@@ -3,10 +3,14 @@ package be.orbinson.aem.groovy.console.reports.servlets
 import be.orbinson.aem.groovy.console.configuration.ConfigurationService
 import be.orbinson.aem.groovy.console.reports.ReportException
 import be.orbinson.aem.groovy.console.reports.ReportExporterRegistry
+import be.orbinson.aem.groovy.console.reports.ReportScheduleService
 import be.orbinson.aem.groovy.console.reports.ReportService
 import be.orbinson.aem.groovy.console.reports.model.ReportDefinition
+import be.orbinson.aem.groovy.console.reports.model.ReportDistributionTarget
 import be.orbinson.aem.groovy.console.reports.model.ReportParameter
 import be.orbinson.aem.groovy.console.reports.model.ReportParameterType
+import be.orbinson.aem.groovy.console.reports.impl.ReportImpersonation
+import be.orbinson.aem.groovy.console.reports.model.ReportSchedule
 import groovy.util.logging.Slf4j
 import org.apache.sling.api.SlingHttpServletRequest
 import org.apache.sling.api.SlingHttpServletResponse
@@ -16,6 +20,7 @@ import org.osgi.service.component.annotations.Reference
 import javax.servlet.Servlet
 import javax.servlet.ServletException
 
+import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.EXECUTOR_SYSTEM_USER_NAME
 import static be.orbinson.aem.groovy.console.reports.constants.ReportsConstants.PARAMETER_NAME
 import static javax.servlet.http.HttpServletResponse.*
 
@@ -40,6 +45,9 @@ class ReportsServlet extends AbstractReportsServlet {
 
     @Reference
     private ReportExporterRegistry exporterRegistry
+
+    @Reference
+    private ReportScheduleService scheduleService
 
     @Reference
     private ConfigurationService configurationService
@@ -101,6 +109,14 @@ class ReportsServlet extends AbstractReportsServlet {
         try {
             def definition = reportService.saveReport(resolver, fromBody(body), resolver.userID)
 
+            // register/refresh/remove the cron job to match the saved schedule
+            scheduleService.reconcile(definition)
+
+            // enable the executor to run this scheduled report as its author (self-scoped, best-effort)
+            if (definition.schedule?.enabled) {
+                ReportImpersonation.grantSelfImpersonation(resolver, EXECUTOR_SYSTEM_USER_NAME)
+            }
+
             writeJsonResponse(response, ReportJsonMapper.definition(definition,
                     reportService.canEdit(resolver, name), exporterRegistry.exporters))
         } catch (IllegalArgumentException e) {
@@ -108,7 +124,8 @@ class ReportsServlet extends AbstractReportsServlet {
         } catch (ReportException e) {
             LOG.warn("error saving report : {}", name, e)
 
-            writeError(response, SC_FORBIDDEN, "Not allowed to save report (check repository permissions): $name")
+            // covers both the JCR write check and the run-as impersonation gate; surface the reason
+            writeError(response, SC_FORBIDDEN, e.message ?: "Not allowed to save report: $name")
         }
     }
 
@@ -119,8 +136,9 @@ class ReportsServlet extends AbstractReportsServlet {
         // permission — JCR delete access on the report node governs it
         def resolver = request.resourceResolver
         def name = request.getParameter(PARAMETER_NAME)
+        def definition = reportService.getReport(resolver, name)
 
-        if (!reportService.getReport(resolver, name)) {
+        if (!definition) {
             writeError(response, SC_NOT_FOUND, "Report not found: $name")
 
             return
@@ -128,6 +146,9 @@ class ReportsServlet extends AbstractReportsServlet {
 
         try {
             reportService.deleteReport(resolver, name)
+
+            // remove any cron job for the deleted report
+            scheduleService.unschedule(definition.path)
 
             writeJsonResponse(response, [deleted: name])
         } catch (ReportException e) {
@@ -149,7 +170,32 @@ class ReportsServlet extends AbstractReportsServlet {
                 pageSize: body["pageSize"] != null ? (body["pageSize"] as Integer) : null,
                 parameters: (body["parameters"] as List ?: []).withIndex().collect { parameter, index ->
                     parameterFromBody(parameter as Map, index as int)
+                },
+                schedule: body["schedule"] ? scheduleFromBody(body["schedule"] as Map) : null,
+                distributions: (body["distributions"] as List ?: []).collect { target ->
+                    distributionFromBody(target as Map)
                 }
+        )
+    }
+
+    // runAs and scheduledBy are deliberately NOT read from the request body: the service forces both to the
+    // requesting user, so a schedule saved through the UI/API always runs as its author and cannot be pointed
+    // at another user by a forged body
+    static ReportSchedule scheduleFromBody(Map schedule) {
+        new ReportSchedule(
+                enabled: Boolean.TRUE == schedule["enabled"],
+                cronExpression: schedule["cronExpression"] as String,
+                parameterValues: (schedule["parameterValues"] as Map ?: [:]).collectEntries { key, value ->
+                    [(key as String): value == null ? null : value as String]
+                } as Map<String, String>
+        )
+    }
+
+    static ReportDistributionTarget distributionFromBody(Map target) {
+        new ReportDistributionTarget(
+                distributorId: target["distributorId"] as String,
+                format: target["format"] as String,
+                config: (target["config"] as Map ?: [:]) as Map<String, Object>
         )
     }
 

--- a/extensions/reports/bundle/src/main/java/be/orbinson/aem/groovy/console/reports/impl/EmailReportDistributorConfig.java
+++ b/extensions/reports/bundle/src/main/java/be/orbinson/aem/groovy/console/reports/impl/EmailReportDistributorConfig.java
@@ -1,0 +1,16 @@
+package be.orbinson.aem.groovy.console.reports.impl;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition(name = "AEM Groovy Console Reports - Email Distributor",
+        description = "Distributes report results by email via the AEM mail service. Optionally restrict where "
+                + "reports may be sent with a recipient-domain allowlist.")
+public @interface EmailReportDistributorConfig {
+
+    @AttributeDefinition(name = "Allowed recipient domains",
+            description = "Optional allowlist of recipient email domains (e.g. example.com). When empty, reports "
+                    + "may be sent to any address. When set, every recipient's domain must match one of these "
+                    + "entries or the distribution is rejected.")
+    String[] allowedRecipientDomains() default {};
+}

--- a/extensions/reports/bundle/src/main/java/be/orbinson/aem/groovy/console/reports/impl/FilesystemReportDistributorConfig.java
+++ b/extensions/reports/bundle/src/main/java/be/orbinson/aem/groovy/console/reports/impl/FilesystemReportDistributorConfig.java
@@ -1,0 +1,19 @@
+package be.orbinson.aem.groovy.console.reports.impl;
+
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+
+@ObjectClassDefinition(name = "AEM Groovy Console Reports - Filesystem Distributor",
+        description = "Distributes report results to the local filesystem. Disabled by default; writing to disk is "
+                + "a sensitive capability, so enable it deliberately and constrain it with an allowed root directory.")
+public @interface FilesystemReportDistributorConfig {
+
+    @AttributeDefinition(name = "Enabled",
+            description = "Enable the filesystem report distributor.")
+    boolean enabled() default false;
+
+    @AttributeDefinition(name = "Allowed root directory",
+            description = "Absolute path that all target directories must resolve within. Distribution targets "
+                    + "resolving outside this root are rejected. Required when enabled.")
+    String allowedRootDirectory() default "";
+}

--- a/extensions/reports/bundle/src/main/java/be/orbinson/aem/groovy/console/reports/impl/ReportsConfigurationProperties.java
+++ b/extensions/reports/bundle/src/main/java/be/orbinson/aem/groovy/console/reports/impl/ReportsConfigurationProperties.java
@@ -17,4 +17,14 @@ public @interface ReportsConfigurationProperties {
         description = "Maximum number of result rows persisted per execution.  A run that produces more is "
             + "failed instead of storing an oversized result.  0 means unlimited.")
     int maxResultRows() default 0;
+
+    @AttributeDefinition(name = "Enable Scheduled Reports",
+        description = "When disabled, reports cannot run on a schedule: existing schedules are unregistered on "
+            + "startup, any scheduled run that still fires is skipped, and the scheduling UI is hidden.")
+    boolean schedulingEnabled() default true;
+
+    @AttributeDefinition(name = "Enable Report Distribution",
+        description = "When disabled, report results are never distributed: configured distributions are skipped "
+            + "for both scheduled and manual runs, and the distribution UI is hidden.")
+    boolean distributionEnabled() default true;
 }

--- a/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/distributor/EmailReportDistributorTest.groovy
+++ b/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/distributor/EmailReportDistributorTest.groovy
@@ -13,8 +13,10 @@ import org.apache.commons.mail.MultiPartEmail
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertInstanceOf
 import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 class EmailReportDistributorTest {
 
@@ -76,6 +78,15 @@ class EmailReportDistributorTest {
         assertThrows(ReportException) {
             distributor.distribute(execution(), reportData(), target([recipients: "a@example.com"]))
         }
+    }
+
+    @Test
+    void "is available only when a mail service is bound"() {
+        def distributor = new EmailReportDistributor()
+        assertFalse(distributor.available, "no mail service should mean unavailable")
+
+        distributor.mailService = [send: { Email email -> null }] as MailService
+        assertTrue(distributor.available, "a bound mail service should mean available")
     }
 
     @Test

--- a/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/distributor/EmailReportDistributorTest.groovy
+++ b/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/distributor/EmailReportDistributorTest.groovy
@@ -1,0 +1,123 @@
+package be.orbinson.aem.groovy.console.reports.distributor
+
+import be.orbinson.aem.groovy.console.reports.ReportException
+import be.orbinson.aem.groovy.console.reports.ReportExporterRegistry
+import be.orbinson.aem.groovy.console.reports.data.ReportData
+import be.orbinson.aem.groovy.console.reports.exporter.CsvReportExporter
+import be.orbinson.aem.groovy.console.reports.model.ReportDistributionTarget
+import be.orbinson.aem.groovy.console.reports.model.ReportExecution
+import be.orbinson.aem.groovy.console.reports.model.ReportExecutionStatus
+import com.day.cq.mailer.MailService
+import org.apache.commons.mail.Email
+import org.apache.commons.mail.MultiPartEmail
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertInstanceOf
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+class EmailReportDistributorTest {
+
+    private static final ReportExporterRegistry EXPORTER_REGISTRY = [
+            getExporter : { String format -> format == "csv" ? new CsvReportExporter() : null },
+            getExporters: { [new CsvReportExporter()] }
+    ] as ReportExporterRegistry
+
+    private static ReportData reportData() {
+        def data = new ReportData()
+        data.column("Name")
+        data.row("Home")
+        data
+    }
+
+    private static ReportExecution execution() {
+        new ReportExecution(reportName: "traffic", status: ReportExecutionStatus.SUCCESS, finishedAt: Calendar.instance)
+    }
+
+    private static ReportDistributionTarget target(Map config) {
+        new ReportDistributionTarget(distributorId: "email", format: "csv", config: config)
+    }
+
+    private static EmailReportDistributor distributor(List<Email> sent) {
+        def distributor = new EmailReportDistributor()
+        distributor.exporterRegistry = EXPORTER_REGISTRY
+        distributor.mailService = [send: { Email email -> sent << email; null }] as MailService
+        distributor
+    }
+
+    @Test
+    void "sends an email with the recipients from a comma-separated string"() {
+        def sent = []
+        def distributor = distributor(sent)
+
+        distributor.distribute(execution(), reportData(), target([recipients: "a@example.com, b@example.com"]))
+
+        assertEquals(1, sent.size())
+        def email = assertInstanceOf(MultiPartEmail, sent[0])
+        assertEquals(2, email.toAddresses.size())
+    }
+
+    @Test
+    void "sends an email with the recipients from a list"() {
+        def sent = []
+        def distributor = distributor(sent)
+
+        distributor.distribute(execution(), reportData(), target([recipients: ["a@example.com"]]))
+
+        assertEquals(1, sent.size())
+        assertEquals("a@example.com", (sent[0] as MultiPartEmail).toAddresses[0].address)
+    }
+
+    @Test
+    void "fails when the mail service is unavailable"() {
+        def distributor = new EmailReportDistributor()
+        distributor.exporterRegistry = EXPORTER_REGISTRY
+
+        assertThrows(ReportException) {
+            distributor.distribute(execution(), reportData(), target([recipients: "a@example.com"]))
+        }
+    }
+
+    @Test
+    void "fails when there are no recipients"() {
+        def distributor = distributor([])
+
+        assertThrows(ReportException) {
+            distributor.distribute(execution(), reportData(), target([:]))
+        }
+    }
+
+    @Test
+    void "sends when every recipient domain is on the allowlist"() {
+        def sent = []
+        def distributor = distributor(sent)
+        distributor.allowedRecipientDomains = ["example.com"] as Set
+
+        distributor.distribute(execution(), reportData(), target([recipients: "a@example.com, b@EXAMPLE.com"]))
+
+        assertEquals(1, sent.size())
+    }
+
+    @Test
+    void "rejects a recipient whose domain is not on the allowlist"() {
+        def sent = []
+        def distributor = distributor(sent)
+        distributor.allowedRecipientDomains = ["example.com"] as Set
+
+        assertThrows(ReportException) {
+            distributor.distribute(execution(), reportData(),
+                    target([recipients: "a@example.com, evil@attacker.com"]))
+        }
+        assertEquals(0, sent.size())
+    }
+
+    @Test
+    void "allowlist check permits anything when empty and enforces domains when set"() {
+        EmailReportDistributor.assertRecipientsAllowed(["a@anywhere.com"] as Set, [] as Set)
+        EmailReportDistributor.assertRecipientsAllowed(["a@example.com"] as Set, ["example.com"] as Set)
+
+        assertThrows(ReportException) {
+            EmailReportDistributor.assertRecipientsAllowed(["a@other.com"] as Set, ["example.com"] as Set)
+        }
+    }
+}

--- a/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/distributor/FilesystemReportDistributorTest.groovy
+++ b/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/distributor/FilesystemReportDistributorTest.groovy
@@ -1,0 +1,108 @@
+package be.orbinson.aem.groovy.console.reports.distributor
+
+import be.orbinson.aem.groovy.console.reports.ReportException
+import be.orbinson.aem.groovy.console.reports.ReportExporterRegistry
+import be.orbinson.aem.groovy.console.reports.data.ReportColumnType
+import be.orbinson.aem.groovy.console.reports.data.ReportData
+import be.orbinson.aem.groovy.console.reports.exporter.CsvReportExporter
+import be.orbinson.aem.groovy.console.reports.impl.FilesystemReportDistributorConfig
+import be.orbinson.aem.groovy.console.reports.model.ReportDistributionTarget
+import be.orbinson.aem.groovy.console.reports.model.ReportExecution
+import be.orbinson.aem.groovy.console.reports.model.ReportExecutionStatus
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import java.nio.file.Path
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+class FilesystemReportDistributorTest {
+
+    private static final ReportExporterRegistry EXPORTER_REGISTRY = [
+            getExporter : { String format -> format == "csv" ? new CsvReportExporter() : null },
+            getExporters: { [new CsvReportExporter()] }
+    ] as ReportExporterRegistry
+
+    private static ReportData reportData() {
+        def data = new ReportData()
+        data.column("Name", ReportColumnType.STRING)
+        data.column("Views", ReportColumnType.NUMBER)
+        data.row("Home", 42)
+        data
+    }
+
+    private static ReportExecution execution() {
+        new ReportExecution(reportName: "traffic", status: ReportExecutionStatus.SUCCESS, finishedAt: Calendar.instance)
+    }
+
+    private static FilesystemReportDistributor distributor(String root, boolean enabled = true) {
+        def distributor = new FilesystemReportDistributor()
+        distributor.exporterRegistry = EXPORTER_REGISTRY
+        distributor.activate([enabled: { enabled }, allowedRootDirectory: { root }] as FilesystemReportDistributorConfig)
+        distributor
+    }
+
+    private static ReportDistributionTarget target(Map config) {
+        new ReportDistributionTarget(distributorId: "filesystem", format: "csv", config: config)
+    }
+
+    @Test
+    void "writes the rendered export into the configured directory"(@TempDir Path tempDir) {
+        def distributor = distributor(tempDir.toString())
+
+        distributor.distribute(execution(), reportData(), target([directory: "out", filename: "report.csv"]))
+
+        def file = tempDir.resolve("out/report.csv").toFile()
+        assertTrue(file.exists(), "expected the export file to be written")
+        assertTrue(file.text.contains("Home"), "expected the export to contain the report data")
+    }
+
+    @Test
+    void "defaults the filename when none is configured"(@TempDir Path tempDir) {
+        def distributor = distributor(tempDir.toString())
+
+        distributor.distribute(execution(), reportData(), target([directory: "."]))
+
+        def written = tempDir.toFile().listFiles({ file -> file.name.endsWith(".csv") } as FileFilter)
+        assertEquals(1, written.length)
+        assertTrue(written[0].name.startsWith("traffic-"), "expected report-timestamp default filename")
+    }
+
+    @Test
+    void "rejects a directory that escapes the allowed root"(@TempDir Path tempDir) {
+        def distributor = distributor(tempDir.resolve("sandbox").toString())
+
+        assertThrows(ReportException) {
+            distributor.distribute(execution(), reportData(), target([directory: "../escape"]))
+        }
+    }
+
+    @Test
+    void "rejects a filename that escapes the target directory"(@TempDir Path tempDir) {
+        def distributor = distributor(tempDir.toString())
+
+        assertThrows(ReportException) {
+            distributor.distribute(execution(), reportData(), target([directory: "out", filename: "../../etc/passwd"]))
+        }
+    }
+
+    @Test
+    void "fails when disabled"(@TempDir Path tempDir) {
+        def distributor = distributor(tempDir.toString(), false)
+
+        assertThrows(ReportException) {
+            distributor.distribute(execution(), reportData(), target([directory: "out"]))
+        }
+    }
+
+    @Test
+    void "fails when the target has no directory"(@TempDir Path tempDir) {
+        def distributor = distributor(tempDir.toString())
+
+        assertThrows(ReportException) {
+            distributor.distribute(execution(), reportData(), target([:]))
+        }
+    }
+}

--- a/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/distributor/FilesystemReportDistributorTest.groovy
+++ b/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/distributor/FilesystemReportDistributorTest.groovy
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
 
@@ -95,6 +96,12 @@ class FilesystemReportDistributorTest {
         assertThrows(ReportException) {
             distributor.distribute(execution(), reportData(), target([directory: "out"]))
         }
+    }
+
+    @Test
+    void "is available only when enabled"(@TempDir Path tempDir) {
+        assertTrue(distributor(tempDir.toString(), true).available, "enabled distributor should be available")
+        assertFalse(distributor(tempDir.toString(), false).available, "disabled distributor should be unavailable")
     }
 
     @Test

--- a/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/impl/CronValidatorTest.groovy
+++ b/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/impl/CronValidatorTest.groovy
@@ -1,0 +1,37 @@
+package be.orbinson.aem.groovy.console.reports.impl
+
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+class CronValidatorTest {
+
+    @Test
+    void "accepts a valid 6-field expression"() {
+        CronValidator.validate("0 0 6 * * ?")
+    }
+
+    @Test
+    void "accepts a valid 7-field expression with a year"() {
+        CronValidator.validate("0 30 2 ? * MON 2026")
+    }
+
+    @Test
+    void "rejects a blank expression"() {
+        assertThrows(IllegalArgumentException) { CronValidator.validate("  ") }
+        assertThrows(IllegalArgumentException) { CronValidator.validate(null) }
+    }
+
+    @Test
+    void "rejects the wrong number of fields"() {
+        assertThrows(IllegalArgumentException) { CronValidator.validate("0 0 6 * *") }
+        assertThrows(IllegalArgumentException) { CronValidator.validate("0 0 6 * * ? 2026 extra") }
+    }
+
+    @Test
+    void "rejects sub-minute schedules"() {
+        assertThrows(IllegalArgumentException) { CronValidator.validate("* * * * * ?") }
+        assertThrows(IllegalArgumentException) { CronValidator.validate("0/5 * * * * ?") }
+        assertThrows(IllegalArgumentException) { CronValidator.validate("99 0 6 * * ?") }
+    }
+}

--- a/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportDistributorRegistryTest.groovy
+++ b/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/impl/DefaultReportDistributorRegistryTest.groovy
@@ -1,0 +1,40 @@
+package be.orbinson.aem.groovy.console.reports.impl
+
+import be.orbinson.aem.groovy.console.reports.ReportDistributor
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNull
+
+class DefaultReportDistributorRegistryTest {
+
+    private static ReportDistributor distributor(String id) {
+        [getId: { id }, getName: { id.capitalize() }, distribute: { a, b, c -> }] as ReportDistributor
+    }
+
+    @Test
+    void "lists distributors sorted by id and looks them up by id"() {
+        def registry = new DefaultReportDistributorRegistry()
+        def email = distributor("email")
+        def filesystem = distributor("filesystem")
+
+        registry.bindReportDistributor(filesystem)
+        registry.bindReportDistributor(email)
+
+        assertEquals(["email", "filesystem"], registry.distributors*.id)
+        assertEquals(email, registry.getDistributor("email"))
+        assertNull(registry.getDistributor("unknown"))
+    }
+
+    @Test
+    void "unbinding removes a distributor"() {
+        def registry = new DefaultReportDistributorRegistry()
+        def email = distributor("email")
+
+        registry.bindReportDistributor(email)
+        registry.unbindReportDistributor(email)
+
+        assertEquals([], registry.distributors)
+        assertNull(registry.getDistributor("email"))
+    }
+}

--- a/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/impl/ReportImpersonationTest.groovy
+++ b/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/impl/ReportImpersonationTest.groovy
@@ -1,0 +1,48 @@
+package be.orbinson.aem.groovy.console.reports.impl
+
+import be.orbinson.aem.groovy.console.reports.ReportException
+import org.apache.sling.api.resource.LoginException
+import org.apache.sling.api.resource.ResourceResolver
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertSame
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+class ReportImpersonationTest {
+
+    private static ResourceResolver executor(Closure cloneImpl = { Map m -> throw new LoginException("denied") }) {
+        [getUserID: { "reports-executor" }, clone: cloneImpl] as ResourceResolver
+    }
+
+    @Test
+    void "runResolver returns the executor itself when no run-as is configured"() {
+        def executorResolver = executor()
+
+        assertSame(executorResolver, ReportImpersonation.runResolver(executorResolver, null))
+        assertSame(executorResolver, ReportImpersonation.runResolver(executorResolver, ""))
+        assertSame(executorResolver, ReportImpersonation.runResolver(executorResolver, "reports-executor"))
+        assertFalse(ReportImpersonation.isImpersonated(executorResolver, executorResolver))
+    }
+
+    @Test
+    void "runResolver impersonates the configured run-as user"() {
+        def impersonated = [getUserID: { "reporter" }] as ResourceResolver
+        def executorResolver = executor({ Map m -> impersonated })
+
+        def runResolver = ReportImpersonation.runResolver(executorResolver, "reporter")
+
+        assertSame(impersonated, runResolver)
+        assertTrue(ReportImpersonation.isImpersonated(executorResolver, runResolver))
+    }
+
+    @Test
+    void "runResolver fails closed when the executor may not impersonate the run-as"() {
+        def executorResolver = executor() // default clone throws LoginException
+
+        assertThrows(ReportException) {
+            ReportImpersonation.runResolver(executorResolver, "reporter")
+        }
+    }
+}

--- a/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportsServletBodyTest.groovy
+++ b/extensions/reports/bundle/src/test/groovy/be/orbinson/aem/groovy/console/reports/servlets/ReportsServletBodyTest.groovy
@@ -1,0 +1,77 @@
+package be.orbinson.aem.groovy.console.reports.servlets
+
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+class ReportsServletBodyTest {
+
+    @Test
+    void "parses schedule from the request body, ignoring any client-supplied runAs and scheduledBy"() {
+        def schedule = ReportsServlet.scheduleFromBody([
+                enabled        : true,
+                cronExpression : "0 0 6 * * ?",
+                runAs          : "attacker", // must be ignored — forced to the requesting user server-side
+                scheduledBy    : "attacker", // must be ignored — set server-side
+                parameterValues: [region: "eu", limit: 10]
+        ])
+
+        assertTrue(schedule.enabled)
+        assertEquals("0 0 6 * * ?", schedule.cronExpression)
+        assertNull(schedule.runAs, "runAs must never be taken from the request body")
+        assertNull(schedule.scheduledBy, "scheduledBy must never be taken from the request body")
+        assertEquals(["region": "eu", "limit": "10"], schedule.parameterValues)
+    }
+
+    @Test
+    void "defaults schedule fields when omitted"() {
+        def schedule = ReportsServlet.scheduleFromBody([:])
+
+        assertFalse(schedule.enabled)
+        assertNull(schedule.cronExpression)
+        assertNull(schedule.runAs)
+        assertEquals([:], schedule.parameterValues)
+    }
+
+    @Test
+    void "parses a distribution target with its config"() {
+        def target = ReportsServlet.distributionFromBody([
+                distributorId: "email",
+                format       : "xlsx",
+                config       : [recipients: "a@example.com, b@example.com", subject: "Weekly"]
+        ])
+
+        assertEquals("email", target.distributorId)
+        assertEquals("xlsx", target.format)
+        assertEquals("a@example.com, b@example.com", target.config["recipients"])
+        assertEquals("Weekly", target.config["subject"])
+    }
+
+    @Test
+    void "fromBody includes schedule and distributions"() {
+        def definition = ReportsServlet.fromBody([
+                name         : "traffic",
+                script       : "report.data()",
+                schedule     : [enabled: true, cronExpression: "0 0 * * * ?"],
+                distributions: [
+                        [distributorId: "filesystem", format: "csv", config: [directory: "/var/reports"]]
+                ]
+        ])
+
+        assertEquals("traffic", definition.name)
+        assertTrue(definition.schedule.enabled)
+        assertEquals(1, definition.distributions.size())
+        assertEquals("filesystem", definition.distributions[0].distributorId)
+    }
+
+    @Test
+    void "fromBody leaves schedule null when absent"() {
+        def definition = ReportsServlet.fromBody([name: "traffic", script: "report.data()"])
+
+        assertNull(definition.schedule)
+        assertEquals([], definition.distributions)
+    }
+}

--- a/extensions/reports/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/extensions/reports/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
     <!-- AEM Tools > General entry so business users can reach the reports UI (overlay; AEM-only).
-         Fine-grained includes so other entries under the shared nav nodes are left untouched. -->
-    <filter root="/apps/cq/core/content/nav">
+         merge mode: add this entry without replacing the shared nav folders, so it never wipes the core
+         console's or the migration extension's sibling entries (and they never wipe this one). -->
+    <filter root="/apps/cq/core/content/nav" mode="merge">
         <include pattern="/apps/cq/core/content/nav"/>
         <include pattern="/apps/cq/core/content/nav/tools"/>
         <include pattern="/apps/cq/core/content/nav/tools/general"/>

--- a/extensions/reports/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/extensions/reports/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
     <!-- AEM Tools > General entry so business users can reach the reports UI (overlay; AEM-only).
-         merge mode: add this entry without replacing the shared nav folders, so it never wipes the core
-         console's or the migration extension's sibling entries (and they never wipe this one). -->
+         merge the shared nav folders (create if missing, never replace) so this package never removes the core
+         console's or the migration extension's sibling entries. -->
     <filter root="/apps/cq/core/content/nav" mode="merge">
         <include pattern="/apps/cq/core/content/nav"/>
         <include pattern="/apps/cq/core/content/nav/tools"/>
         <include pattern="/apps/cq/core/content/nav/tools/general"/>
-        <include pattern="/apps/cq/core/content/nav/tools/general/groovyconsole-reports(.*)?"/>
     </filter>
+    <!-- own only this leaf entry, so it is always (re)created even under a pre-existing shared folder -->
+    <filter root="/apps/cq/core/content/nav/tools/general/groovyconsole-reports"/>
     <!-- the reports SPA assets (built by extensions/reports/ui.frontend), on a reports-owned path -->
     <filter root="/apps/groovyconsole-reports"/>
 </workspaceFilter>

--- a/extensions/reports/ui.config/src/main/content/jcr_root/apps/groovyconsole-reports-config/osgiconfig/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-groovyconsole-reports.config
+++ b/extensions/reports/ui.config/src/main/content/jcr_root/apps/groovyconsole-reports-config/osgiconfig/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-groovyconsole-reports.config
@@ -4,11 +4,18 @@ create path /conf/groovyconsole(sling:Folder)
 create path /conf/groovyconsole/reports(sling:Folder)
 create path /var/groovyconsole/reports(sling:Folder)
 create path /var/groovyconsole/reports/executions(sling:Folder)
+create path /apps/groovyconsole-reports-definitions(sling:Folder)
 
 create service user aem-groovy-console-reports-service with path system/aem-groovy-console
 set ACL for aem-groovy-console-reports-service
     allow jcr:read on /conf/groovyconsole
     allow jcr:all on /conf/groovyconsole/reports
     allow jcr:all on /var/groovyconsole/reports
+    allow jcr:read on /apps/groovyconsole-reports-definitions
+end
+
+create service user aem-groovy-console-reports-executor with path system/aem-groovy-console
+set ACL for aem-groovy-console-reports-executor
+    allow jcr:read on /content
 end
 "]

--- a/extensions/reports/ui.config/src/main/content/jcr_root/apps/groovyconsole-reports-config/osgiconfig/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-groovy-console-reports-executor.xml
+++ b/extensions/reports/ui.config/src/main/content/jcr_root/apps/groovyconsole-reports-config/osgiconfig/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-groovy-console-reports-executor.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:OsgiConfig"
+    user.mapping="aem-groovy-console-reports-bundle:executor=[aem-groovy-console-reports-executor]"/>

--- a/extensions/reports/ui.frontend/src/api/reports-api.ts
+++ b/extensions/reports/ui.frontend/src/api/reports-api.ts
@@ -13,6 +13,7 @@ import type {
   ReportParameterValue,
   ReportPreviewResponse,
   ReportQueryAuditResponse,
+  ReportsFeatureConfig,
   ResultPage,
   SaveReportRequest,
 } from './reports-types';
@@ -21,6 +22,15 @@ const BASE = '/bin/groovyconsole/reports';
 
 export function listReports(): Promise<ReportListResponse> {
   return getJsonWithError<ReportListResponse>(`${BASE}.json`);
+}
+
+/** Global reports feature flags (OSGi). Falls back to all-enabled if the endpoint is unavailable. */
+export async function getReportsConfig(): Promise<ReportsFeatureConfig> {
+  try {
+    return await getJsonWithError<ReportsFeatureConfig>(`${BASE}/config.json`);
+  } catch {
+    return { schedulingEnabled: true, distributionEnabled: true };
+  }
 }
 
 export function getReport(name: string): Promise<ReportDefinition> {

--- a/extensions/reports/ui.frontend/src/api/reports-api.ts
+++ b/extensions/reports/ui.frontend/src/api/reports-api.ts
@@ -2,6 +2,8 @@ import { config } from '@console/config';
 import { delJson, getJson, getJsonWithError, postJson } from '@console/api/client';
 import type {
   BrowseResponse,
+  DistributionTarget,
+  DistributorsResponse,
   PathType,
   ReportDefinition,
   ReportExecution,
@@ -40,6 +42,19 @@ export function previewReport(
 
 export function executeReport(name: string, parameters: Record<string, string>): Promise<ReportExecution> {
   return postJson<ReportExecution>(`${BASE}/execute`, { name, parameters });
+}
+
+/** Available distributors and export formats, for the report editor's distribution section. */
+export function listDistributors(): Promise<DistributorsResponse> {
+  return getJsonWithError<DistributorsResponse>(`${BASE}/distributors.json`);
+}
+
+/** Distribute an already-completed successful execution on demand. */
+export function distributeExecution(
+  executionId: string,
+  targets: DistributionTarget[],
+): Promise<ReportExecution> {
+  return postJson<ReportExecution>(`${BASE}/distribute`, { executionId, targets });
 }
 
 export function getExecutions(name: string): Promise<ReportExecutionsResponse> {

--- a/extensions/reports/ui.frontend/src/api/reports-types.ts
+++ b/extensions/reports/ui.frontend/src/api/reports-types.ts
@@ -62,11 +62,42 @@ export interface ReportParameter {
   order: number;
 }
 
+/** Cron schedule for unattended report runs. */
+export interface ReportSchedule {
+  enabled: boolean;
+  cronExpression?: string | null;
+  /** Optional user to run as; blank runs as the reports service user. */
+  runAs?: string | null;
+  /** Set server-side to the user that saved the schedule; read-only in the UI. */
+  scheduledBy?: string | null;
+  /** Fixed parameter values used for scheduled runs. */
+  parameterValues: Record<string, string>;
+}
+
+/** A configured distribution target: which distributor, which export format, and its config. */
+export interface DistributionTarget {
+  distributorId: string;
+  format: string;
+  config: Record<string, unknown>;
+}
+
+export interface Distributor {
+  id: string;
+  name: string;
+}
+
+export interface DistributorsResponse {
+  distributors: Distributor[];
+  formats: ExportFormat[];
+}
+
 export interface ReportDefinition extends ReportSummary {
   /** Inline Groovy script. */
   script?: string | null;
   pageSize?: number | null;
   parameters: ReportParameter[];
+  schedule?: ReportSchedule | null;
+  distributions: DistributionTarget[];
   created?: string | null;
   createdBy?: string | null;
   lastModified?: string | null;
@@ -83,6 +114,8 @@ export interface SaveReportRequest {
   script?: string;
   pageSize?: number;
   parameters?: Array<Omit<ReportParameter, 'order'> & { order?: number }>;
+  schedule?: ReportSchedule | null;
+  distributions?: DistributionTarget[];
 }
 
 export interface ReportExecution {
@@ -99,6 +132,8 @@ export interface ReportExecution {
   parameterValues: Record<string, unknown>;
   output?: string | null;
   exceptionStackTrace?: string | null;
+  /** Distribution failures recorded after a successful run (empty when all succeeded). */
+  distributionErrors?: string[] | null;
 }
 
 export interface ReportExecutionsResponse {

--- a/extensions/reports/ui.frontend/src/api/reports-types.ts
+++ b/extensions/reports/ui.frontend/src/api/reports-types.ts
@@ -85,8 +85,8 @@ export interface ReportSchedule {
   runAs?: string | null;
   /** Set server-side to the user that saved the schedule; read-only in the UI. */
   scheduledBy?: string | null;
-  /** Fixed parameter values used for scheduled runs. */
-  parameterValues: Record<string, string>;
+  /** Fixed parameter values used for scheduled runs (a scalar, or a list for a `multiple` parameter). */
+  parameterValues: Record<string, ReportParameterValue>;
 }
 
 /** A configured distribution target: which distributor, which export format, and its config. */

--- a/extensions/reports/ui.frontend/src/api/reports-types.ts
+++ b/extensions/reports/ui.frontend/src/api/reports-types.ts
@@ -59,6 +59,12 @@ export interface ReportListResponse {
   canManage: boolean;
 }
 
+/** Global reports feature flags (OSGi); when a flag is false the matching UI section is hidden. */
+export interface ReportsFeatureConfig {
+  schedulingEnabled: boolean;
+  distributionEnabled: boolean;
+}
+
 export interface ReportParameter {
   name: string;
   label: string;
@@ -126,6 +132,9 @@ export interface ReportDefinition extends ReportSummary {
   lastModified?: string | null;
   lastModifiedBy?: string | null;
   exportFormats: ExportFormat[];
+  /** Global OSGi feature flags: when false, the UI hides the scheduling / distribution sections. */
+  schedulingEnabled?: boolean;
+  distributionEnabled?: boolean;
 }
 
 /** Definition payload for create/update (read-only fields omitted). */

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-parameter-fields.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-parameter-fields.ts
@@ -1,0 +1,348 @@
+import { html, LitElement, nothing } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { ApiError } from '@console/api/client';
+import { listChildPaths, resolveDynamicOptions } from '../../api/reports-api';
+import type { BrowseType, DynamicOption, ReportParameter, ReportParameterValue } from '../../api/reports-types';
+import { renderMultifield } from './multifield';
+import type { GcrPathBrowser } from './gcr-path-browser';
+
+/**
+ * Reusable typed inputs for a set of report parameters, bound to a values map. Renders the same rich controls as
+ * the run form — dropdowns (SELECT/DYNAMIC), a repository/tag browser (PATH/TAG), a date picker (DATE), a checkbox
+ * (BOOLEAN) and a multifield for `multiple` parameters — and emits a `gcr-values-change` event carrying the full
+ * updated values map. The host owns the values; this component owns the auxiliary UI state (dynamic options,
+ * path suggestions, the browser dialog).
+ */
+@customElement('gcr-parameter-fields')
+export class GcrParameterFields extends LitElement {
+  @property({ attribute: false }) parameters: ReportParameter[] = [];
+  @property({ attribute: false }) values: Record<string, ReportParameterValue> = {};
+  /** Report name, needed to resolve a saved DYNAMIC parameter's options. */
+  @property() reportName = '';
+  /** Validation messages to surface per parameter, keyed by name. */
+  @property({ attribute: false }) errors: Record<string, string> = {};
+
+  @state() private pathSuggestions: Record<string, string[]> = {};
+  @state() private dynamicOptions: Record<string, DynamicOption[]> = {};
+  @state() private dynamicLoading: Record<string, boolean> = {};
+  @state() private dynamicErrors: Record<string, string> = {};
+
+  private browsing: { name: string; index: number | null; isTag: boolean } | null = null;
+  private pathSuggestionSeq: Record<string, number> = {};
+  private disposed = false;
+
+  @query('gcr-path-browser') private pathBrowser?: GcrPathBrowser;
+
+  createRenderRoot(): this {
+    return this;
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.disposed = false;
+  }
+
+  disconnectedCallback(): void {
+    this.disposed = true;
+    super.disconnectedCallback();
+  }
+
+  render() {
+    return html`
+      <div
+        @gcr-path-selected=${(event: CustomEvent<{ path: string; id?: string | null }>) =>
+          this.onPathSelected(event)}
+      >
+        <gcr-path-browser></gcr-path-browser>
+        <div class="gcr-form-grid">${this.parameters.map((parameter) => this.renderParameter(parameter))}</div>
+      </div>
+    `;
+  }
+
+  private renderParameter(parameter: ReportParameter) {
+    const error = this.errors[parameter.name];
+    const label = html`
+      <sp-field-label for="pv-${parameter.name}" ?required=${parameter.required}>
+        ${parameter.label || parameter.name}
+      </sp-field-label>
+    `;
+    const errorMessage = error
+      ? html`<sp-help-text variant="negative" role="alert">${error}</sp-help-text>`
+      : nothing;
+
+    if (parameter.multiple) {
+      return html`
+        <div class="gcr-field">
+          ${label}
+          ${renderMultifield({
+            entries: this.valueList(parameter.name),
+            renderEntry: (entry, index) =>
+              this.renderControl(
+                parameter,
+                index === 0 ? `pv-${parameter.name}` : `pv-${parameter.name}-${index}`,
+                entry,
+                !!error,
+                index,
+              ),
+            onAdd: () => this.addValue(parameter.name),
+            onRemove: (index) => this.removeValue(parameter.name, index),
+          })}
+          ${errorMessage}
+        </div>
+      `;
+    }
+
+    if (parameter.type === 'BOOLEAN') {
+      return html`
+        <div class="gcr-field">
+          ${this.renderControl(parameter, `pv-${parameter.name}`, this.valueScalar(parameter.name), !!error, null)}
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="gcr-field">
+        ${label}
+        ${this.renderControl(parameter, `pv-${parameter.name}`, this.valueScalar(parameter.name), !!error, null)}
+        ${errorMessage}
+      </div>
+    `;
+  }
+
+  private renderControl(parameter: ReportParameter, id: string, value: string, invalid: boolean, index: number | null) {
+    const onChange = (newValue: string): void => this.setValue(parameter.name, index, newValue);
+
+    switch (parameter.type) {
+      case 'BOOLEAN':
+        return html`
+          <sp-checkbox
+            id=${id}
+            ?checked=${value === 'true'}
+            @change=${(event: Event) => onChange((event.target as HTMLInputElement).checked ? 'true' : 'false')}
+          >
+            ${parameter.label || parameter.name}
+          </sp-checkbox>
+        `;
+      case 'SELECT':
+        return html`
+          <sp-picker
+            id=${id}
+            value=${value}
+            ?invalid=${invalid}
+            @change=${(event: Event) => onChange((event.target as HTMLInputElement).value)}
+          >
+            ${parameter.options.map((option) => html`<sp-menu-item value=${option}>${option}</sp-menu-item>`)}
+          </sp-picker>
+        `;
+      case 'DATE':
+        return html`
+          <input
+            id=${id}
+            class="gcr-date-input"
+            type="date"
+            .value=${value}
+            @input=${(event: Event) => onChange((event.target as HTMLInputElement).value)}
+          />
+        `;
+      case 'NUMBER':
+        return html`
+          <sp-textfield
+            id=${id}
+            type="number"
+            value=${value}
+            ?invalid=${invalid}
+            @input=${(event: Event) => onChange((event.target as HTMLInputElement).value)}
+          ></sp-textfield>
+        `;
+      case 'PATH':
+        return this.renderPathControl(parameter, id, value, index);
+      case 'TAG':
+        return this.renderTagControl(parameter, id, value, index);
+      case 'DYNAMIC':
+        return this.renderDynamicControl(parameter, id, value, invalid, index);
+      default:
+        return html`
+          <sp-textfield
+            id=${id}
+            value=${value}
+            ?invalid=${invalid}
+            @input=${(event: Event) => onChange((event.target as HTMLInputElement).value)}
+          ></sp-textfield>
+        `;
+    }
+  }
+
+  private renderPathControl(parameter: ReportParameter, id: string, value: string, index: number | null) {
+    return html`
+      <div class="gcr-path-field">
+        <input
+          id=${id}
+          class="gcr-path-input"
+          list="pv-paths-${id}"
+          .value=${value}
+          placeholder=${parameter.rootPath || '/content'}
+          autocomplete="off"
+          @focus=${() => void this.loadPathSuggestions(parameter.name, value)}
+          @input=${(event: Event) => {
+            const next = (event.target as HTMLInputElement).value;
+            this.setValue(parameter.name, index, next);
+            void this.loadPathSuggestions(parameter.name, next);
+          }}
+        />
+        <datalist id="pv-paths-${id}">
+          ${(this.pathSuggestions[parameter.name] ?? []).map((path) => html`<option value=${path}></option>`)}
+        </datalist>
+        <sp-action-button title="Browse repository" @click=${() => this.openBrowser(parameter, index)}>
+          Browse…
+        </sp-action-button>
+      </div>
+    `;
+  }
+
+  private renderTagControl(parameter: ReportParameter, id: string, value: string, index: number | null) {
+    return html`
+      <div class="gcr-path-field">
+        <sp-textfield
+          id=${id}
+          value=${value}
+          placeholder="namespace:path/to/tag"
+          @input=${(event: Event) => this.setValue(parameter.name, index, (event.target as HTMLInputElement).value)}
+        ></sp-textfield>
+        <sp-action-button title="Browse tags" @click=${() => this.openBrowser(parameter, index)}>
+          Browse tags…
+        </sp-action-button>
+      </div>
+    `;
+  }
+
+  private renderDynamicControl(
+    parameter: ReportParameter,
+    id: string,
+    value: string,
+    invalid: boolean,
+    index: number | null,
+  ) {
+    const options = this.dynamicOptions[parameter.name] ?? [];
+    const errorText = this.dynamicErrors[parameter.name];
+
+    return html`
+      <sp-picker
+        id=${id}
+        value=${value}
+        ?invalid=${invalid}
+        ?pending=${this.dynamicLoading[parameter.name]}
+        @mousedown=${() => void this.loadDynamicOptions(parameter)}
+        @change=${(event: Event) => this.setValue(parameter.name, index, (event.target as HTMLInputElement).value)}
+      >
+        ${options.map((option) => html`<sp-menu-item value=${option.value}>${option.label}</sp-menu-item>`)}
+      </sp-picker>
+      ${errorText ? html`<sp-help-text variant="negative" role="alert">${errorText}</sp-help-text>` : nothing}
+    `;
+  }
+
+  // value helpers: a parameter's value is a scalar, or an array for a `multiple` parameter
+
+  private valueList(name: string): string[] {
+    const value = this.values[name];
+    if (Array.isArray(value)) {
+      return value.length ? value : [''];
+    }
+    return value ? [value] : [''];
+  }
+
+  private valueScalar(name: string): string {
+    const value = this.values[name];
+    return Array.isArray(value) ? (value[0] ?? '') : (value ?? '');
+  }
+
+  /** Apply a change to the values map and notify the host. */
+  private emitValues(values: Record<string, ReportParameterValue>): void {
+    this.values = values;
+    this.dispatchEvent(new CustomEvent('gcr-values-change', { detail: values, bubbles: true, composed: true }));
+  }
+
+  private setValue(name: string, index: number | null, newValue: string): void {
+    if (index === null) {
+      this.emitValues({ ...this.values, [name]: newValue });
+    } else {
+      const next = [...this.valueList(name)];
+      next[index] = newValue;
+      this.emitValues({ ...this.values, [name]: next });
+    }
+  }
+
+  private addValue(name: string): void {
+    this.emitValues({ ...this.values, [name]: [...this.valueList(name), ''] });
+  }
+
+  private removeValue(name: string, index: number): void {
+    const next = this.valueList(name).filter((_, entryIndex) => entryIndex !== index);
+    this.emitValues({ ...this.values, [name]: next.length ? next : [''] });
+  }
+
+  private async loadDynamicOptions(parameter: ReportParameter): Promise<void> {
+    const name = parameter.name;
+    this.dynamicLoading = { ...this.dynamicLoading, [name]: true };
+    this.dynamicErrors = { ...this.dynamicErrors, [name]: '' };
+
+    try {
+      const options = await resolveDynamicOptions(this.reportName, name, this.values);
+      if (this.disposed) {
+        return;
+      }
+      this.dynamicOptions = { ...this.dynamicOptions, [name]: options };
+    } catch (error) {
+      if (this.disposed) {
+        return;
+      }
+      this.dynamicErrors = {
+        ...this.dynamicErrors,
+        [name]: error instanceof ApiError ? error.message : 'Could not load options.',
+      };
+    } finally {
+      if (!this.disposed) {
+        this.dynamicLoading = { ...this.dynamicLoading, [name]: false };
+      }
+    }
+  }
+
+  private openBrowser(parameter: ReportParameter, index: number | null): void {
+    if (!this.pathBrowser) {
+      return;
+    }
+    const isTag = parameter.type === 'TAG';
+    this.browsing = { name: parameter.name, index, isTag };
+    this.pathBrowser.browseType = isTag ? 'TAG' : ((parameter.pathType as BrowseType) || 'NODE');
+    this.pathBrowser.rootPath = parameter.rootPath ?? (isTag ? '/content/cq:tags' : '');
+    void this.pathBrowser.openBrowser(isTag ? '' : this.valueAt(parameter.name, index));
+  }
+
+  private valueAt(name: string, index: number | null): string {
+    return index === null ? this.valueScalar(name) : (this.valueList(name)[index] ?? '');
+  }
+
+  private onPathSelected(event: CustomEvent<{ path: string; id?: string | null }>): void {
+    if (!this.browsing) {
+      return;
+    }
+    const { name, index, isTag } = this.browsing;
+    const selected = isTag ? (event.detail.id ?? event.detail.path) : event.detail.path;
+    this.setValue(name, index, selected);
+    this.browsing = null;
+  }
+
+  private async loadPathSuggestions(name: string, value: string): Promise<void> {
+    const cut = value.lastIndexOf('/');
+    const parent = cut > 0 ? value.slice(0, cut) : '/';
+
+    const seq = (this.pathSuggestionSeq[name] ?? 0) + 1;
+    this.pathSuggestionSeq[name] = seq;
+
+    const children = await listChildPaths(parent);
+
+    if (this.disposed || seq !== this.pathSuggestionSeq[name]) {
+      return;
+    }
+    this.pathSuggestions = { ...this.pathSuggestions, [name]: children };
+  }
+}

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
@@ -6,6 +6,7 @@ import {
   auditReportQueries,
   deleteReport,
   getReport,
+  getReportsConfig,
   isQueryAuditAvailable,
   listDistributors,
   previewReport,
@@ -116,6 +117,10 @@ export class GcrReportEditor extends LitElement {
   /** Whether the user may edit the executable Groovy; metadata/parameters stay editable regardless. */
   @state() private canEditScript = true;
 
+  // global OSGi feature flags (default on until the definition loads); hide the sections when disabled
+  @state() private schedulingFeatureEnabled = true;
+  @state() private distributionFeatureEnabled = true;
+
   // schedule state
   @state() private scheduleEnabled = false;
   @state() private cronExpression = '';
@@ -166,6 +171,11 @@ export class GcrReportEditor extends LitElement {
     // is actually opened; the list and run views stay lightweight.
     void import('./gcr-code-editor');
     void this.loadDistributors();
+    // Global feature flags decide whether the scheduling / distribution sections are shown at all.
+    void getReportsConfig().then((config) => {
+      this.schedulingFeatureEnabled = config.schedulingEnabled;
+      this.distributionFeatureEnabled = config.distributionEnabled;
+    });
     // Offer the "Audit queries" action only where the optional query-audit extension is installed.
     void isQueryAuditAvailable().then((available) => {
       this.queryAuditAvailable = available;
@@ -688,6 +698,10 @@ export class GcrReportEditor extends LitElement {
   }
 
   private renderSchedule() {
+    // hidden entirely when scheduling is disabled globally (OSGi)
+    if (!this.schedulingFeatureEnabled) {
+      return nothing;
+    }
     return html`
       <section class="gcr-panel">
         <div class="gcr-panel-header">
@@ -890,6 +904,10 @@ export class GcrReportEditor extends LitElement {
   }
 
   private renderDistribution() {
+    // hidden entirely when distribution is disabled globally (OSGi)
+    if (!this.distributionFeatureEnabled) {
+      return nothing;
+    }
     return html`
       <section class="gcr-panel">
         <div class="gcr-panel-header">

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
@@ -32,6 +32,7 @@ import type { GcrCodeEditor } from './gcr-code-editor';
 import type { GcrPathBrowser } from './gcr-path-browser';
 import { mutePlaceholders } from '@console/util/mute-placeholders';
 import { renderMultifield } from './multifield';
+import './gcr-parameter-fields';
 import { renderResultTable } from './result-cell';
 import { validateRequired } from './validate-parameters';
 import {
@@ -124,7 +125,7 @@ export class GcrReportEditor extends LitElement {
   @state() private cronWeekday = DEFAULT_CRON_PARTS.weekday;
   @state() private cronDayOfMonth = DEFAULT_CRON_PARTS.dayOfMonth;
   @state() private scheduledBy: string | null = null;
-  @state() private scheduleValues: Record<string, string> = {};
+  @state() private scheduleValues: Record<string, ReportParameterValue> = {};
 
   // distribution state
   @state() private distributions: DistributionTarget[] = [];
@@ -711,9 +712,13 @@ export class GcrReportEditor extends LitElement {
               ${this.parameters.length
                 ? html`
                     <h4 class="gcr-subhead">Scheduled parameter values</h4>
-                    <div class="gcr-form-grid">
-                      ${this.parameters.map((parameter) => this.renderScheduleValue(parameter))}
-                    </div>
+                    <gcr-parameter-fields
+                      .parameters=${this.toReportParameters()}
+                      .values=${this.scheduleValues}
+                      .reportName=${this.reportName}
+                      @gcr-values-change=${(event: CustomEvent<Record<string, ReportParameterValue>>) =>
+                        (this.scheduleValues = event.detail)}
+                    ></gcr-parameter-fields>
                   `
                 : nothing}
             `
@@ -864,23 +869,24 @@ export class GcrReportEditor extends LitElement {
     });
   }
 
-  private renderScheduleValue(parameter: ParameterRow) {
-    const label = parameter.label || parameter.name || '(unnamed)';
-    const current = this.scheduleValues[parameter.name] ?? parameter.defaultValue ?? '';
-    const onInput = (event: Event) => {
-      this.scheduleValues = { ...this.scheduleValues, [parameter.name]: (event.target as HTMLInputElement).value };
-    };
-    return html`
-      <div class="gcr-field">
-        <sp-field-label for="schedule-value-${parameter.name}" ?required=${parameter.required}>${label}</sp-field-label>
-        <sp-textfield
-          id="schedule-value-${parameter.name}"
-          type=${parameter.type === 'NUMBER' ? 'number' : 'text'}
-          value=${current}
-          @input=${onInput}
-        ></sp-textfield>
-      </div>
-    `;
+  /** Map the editor's parameter rows to the API parameter shape the shared fields component consumes. */
+  private toReportParameters(): ReportParameter[] {
+    return this.parameters.map((parameter, index) => ({
+      name: parameter.name.trim(),
+      label: parameter.label.trim() || parameter.name.trim(),
+      type: parameter.type,
+      defaultValue: parameter.defaultValue || undefined,
+      required: parameter.required,
+      multiple: parameter.multiple,
+      options: parameter.options
+        .split(',')
+        .map((option) => option.trim())
+        .filter(Boolean),
+      pathType: parameter.type === 'PATH' ? parameter.pathType || 'NODE' : undefined,
+      rootPath: parameter.type === 'PATH' || parameter.type === 'TAG' ? parameter.rootPath || undefined : undefined,
+      optionsScript: parameter.type === 'DYNAMIC' ? parameter.optionsScript || undefined : undefined,
+      order: index,
+    }));
   }
 
   private renderDistribution() {

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
@@ -18,6 +18,16 @@ import type { GcrCodeEditor } from './gcr-code-editor';
 import { mutePlaceholders } from '@console/util/mute-placeholders';
 import { renderResultTable } from './result-cell';
 import { validateRequired } from './validate-parameters';
+import {
+  buildCron,
+  type CronMode,
+  type CronParts,
+  DEFAULT_CRON_PARTS,
+  describeCron,
+  parseCron,
+  validateCron,
+  WEEKDAYS,
+} from '../../util/cron';
 
 const PARAMETER_TYPES: ReportParameterType[] = ['STRING', 'NUMBER', 'BOOLEAN', 'DATE', 'SELECT', 'PATH'];
 
@@ -64,6 +74,11 @@ export class GcrReportEditor extends LitElement {
   // schedule state
   @state() private scheduleEnabled = false;
   @state() private cronExpression = '';
+  @state() private cronMode: CronMode = DEFAULT_CRON_PARTS.mode;
+  @state() private cronHour = DEFAULT_CRON_PARTS.hour;
+  @state() private cronMinute = DEFAULT_CRON_PARTS.minute;
+  @state() private cronWeekday = DEFAULT_CRON_PARTS.weekday;
+  @state() private cronDayOfMonth = DEFAULT_CRON_PARTS.dayOfMonth;
   @state() private scheduledBy: string | null = null;
   @state() private scheduleValues: Record<string, string> = {};
 
@@ -145,6 +160,7 @@ export class GcrReportEditor extends LitElement {
       }));
       this.scheduleEnabled = definition.schedule?.enabled ?? false;
       this.cronExpression = definition.schedule?.cronExpression ?? '';
+      this.applyCronParts(parseCron(this.cronExpression));
       this.scheduledBy = definition.schedule?.scheduledBy ?? null;
       this.scheduleValues = { ...(definition.schedule?.parameterValues ?? {}) };
       this.distributions = (definition.distributions ?? []).map((target) => ({
@@ -426,18 +442,7 @@ export class GcrReportEditor extends LitElement {
 
         ${this.scheduleEnabled
           ? html`
-              <div class="gcr-form-grid">
-                <div class="gcr-field">
-                  <sp-field-label for="schedule-cron" required>Cron expression</sp-field-label>
-                  <sp-textfield
-                    id="schedule-cron"
-                    value=${this.cronExpression}
-                    placeholder="0 0 6 * * ?"
-                    @input=${(event: Event) => (this.cronExpression = (event.target as HTMLInputElement).value)}
-                  ></sp-textfield>
-                  <sp-help-text size="s">Quartz-style cron (seconds minutes hours day month weekday).</sp-help-text>
-                </div>
-              </div>
+              ${this.renderCronBuilder()}
               <sp-help-text size="s">
                 The scheduled report runs as you — with your permissions — so it sees exactly what you can see.
                 ${this.scheduledBy
@@ -456,6 +461,148 @@ export class GcrReportEditor extends LitElement {
           : html`<sp-help-text size="s">The report only runs on demand.</sp-help-text>`}
       </section>
     `;
+  }
+
+  private renderCronBuilder() {
+    const modes: Array<{ value: CronMode; label: string }> = [
+      { value: 'daily', label: 'Every day' },
+      { value: 'weekday', label: 'Every weekday (Mon–Fri)' },
+      { value: 'weekly', label: 'Every week' },
+      { value: 'monthly', label: 'Every month' },
+      { value: 'custom', label: 'Custom cron expression' },
+    ];
+    const cronError = this.cronMode === 'custom' ? validateCron(this.cronExpression) : null;
+    const description = describeCron(this.cronExpression);
+
+    return html`
+      <div class="gcr-form-grid">
+        <div class="gcr-field">
+          <sp-field-label for="schedule-frequency">Frequency</sp-field-label>
+          <sp-picker
+            id="schedule-frequency"
+            value=${this.cronMode}
+            @change=${(event: Event) => this.setCronMode((event.target as HTMLInputElement).value as CronMode)}
+          >
+            ${modes.map((mode) => html`<sp-menu-item value=${mode.value}>${mode.label}</sp-menu-item>`)}
+          </sp-picker>
+        </div>
+
+        ${this.cronMode === 'weekly'
+          ? html`<div class="gcr-field">
+              <sp-field-label for="schedule-weekday">Day of week</sp-field-label>
+              <sp-picker
+                id="schedule-weekday"
+                value=${this.cronWeekday}
+                @change=${(event: Event) => {
+                  this.cronWeekday = (event.target as HTMLInputElement).value;
+                  this.syncCronFromParts();
+                }}
+              >
+                ${WEEKDAYS.map((day) => html`<sp-menu-item value=${day.value}>${day.label}</sp-menu-item>`)}
+              </sp-picker>
+            </div>`
+          : nothing}
+        ${this.cronMode === 'monthly'
+          ? html`<div class="gcr-field">
+              <sp-field-label for="schedule-day-of-month">Day of month</sp-field-label>
+              <sp-textfield
+                id="schedule-day-of-month"
+                type="number"
+                min="1"
+                max="31"
+                value=${String(this.cronDayOfMonth)}
+                @input=${(event: Event) =>
+                  this.updateCronNumber('cronDayOfMonth', (event.target as HTMLInputElement).value, 1, 31)}
+              ></sp-textfield>
+              <sp-help-text size="s">1–31. Months without this day are skipped.</sp-help-text>
+            </div>`
+          : nothing}
+        ${this.cronMode === 'custom'
+          ? html`<div class="gcr-field gcr-field-wide">
+              <sp-field-label for="schedule-cron" required>Cron expression</sp-field-label>
+              <sp-textfield
+                id="schedule-cron"
+                value=${this.cronExpression}
+                placeholder="0 0 6 * * ?"
+                @input=${(event: Event) => (this.cronExpression = (event.target as HTMLInputElement).value)}
+              ></sp-textfield>
+              <sp-help-text size="s" variant=${cronError ? 'negative' : 'neutral'}>
+                ${cronError ??
+                'Quartz-style cron: seconds minutes hours day-of-month month day-of-week [year].'}
+              </sp-help-text>
+            </div>`
+          : html`
+              <div class="gcr-field">
+                <sp-field-label for="schedule-hour">Hour (0–23)</sp-field-label>
+                <sp-textfield
+                  id="schedule-hour"
+                  type="number"
+                  min="0"
+                  max="23"
+                  value=${String(this.cronHour)}
+                  @input=${(event: Event) =>
+                    this.updateCronNumber('cronHour', (event.target as HTMLInputElement).value, 0, 23)}
+                ></sp-textfield>
+              </div>
+              <div class="gcr-field">
+                <sp-field-label for="schedule-minute">Minute (0–59)</sp-field-label>
+                <sp-textfield
+                  id="schedule-minute"
+                  type="number"
+                  min="0"
+                  max="59"
+                  value=${String(this.cronMinute)}
+                  @input=${(event: Event) =>
+                    this.updateCronNumber('cronMinute', (event.target as HTMLInputElement).value, 0, 59)}
+                ></sp-textfield>
+              </div>
+            `}
+      </div>
+      ${description || this.cronExpression
+        ? html`<sp-help-text size="s">
+            ${description ? html`${description} ` : nothing}Cron:
+            <code>${this.cronExpression || '—'}</code>
+          </sp-help-text>`
+        : nothing}
+    `;
+  }
+
+  private applyCronParts(parts: CronParts): void {
+    this.cronMode = parts.mode;
+    this.cronHour = parts.hour;
+    this.cronMinute = parts.minute;
+    this.cronWeekday = parts.weekday;
+    this.cronDayOfMonth = parts.dayOfMonth;
+  }
+
+  private setCronMode(mode: CronMode): void {
+    this.cronMode = mode;
+
+    // a preset owns the expression; custom mode leaves the current expression for the user to edit
+    if (mode !== 'custom') {
+      this.syncCronFromParts();
+    }
+  }
+
+  private updateCronNumber(
+    field: 'cronHour' | 'cronMinute' | 'cronDayOfMonth',
+    raw: string,
+    min: number,
+    max: number,
+  ): void {
+    const parsed = Number.parseInt(raw, 10);
+    this[field] = Number.isNaN(parsed) ? min : Math.min(max, Math.max(min, parsed));
+    this.syncCronFromParts();
+  }
+
+  private syncCronFromParts(): void {
+    this.cronExpression = buildCron({
+      mode: this.cronMode,
+      hour: this.cronHour,
+      minute: this.cronMinute,
+      weekday: this.cronWeekday,
+      dayOfMonth: this.cronDayOfMonth,
+    });
   }
 
   private renderScheduleValue(parameter: ParameterRow) {
@@ -504,34 +651,47 @@ export class GcrReportEditor extends LitElement {
 
   private renderDistributionRow(target: DistributionTarget, index: number) {
     return html`
-      <div class="gcr-parameter-row" role="group" aria-label="Distribution ${index + 1}">
-        <sp-picker
-          aria-label="Distributor"
-          value=${target.distributorId}
-          @change=${(event: Event) =>
-            this.updateDistribution(index, { distributorId: (event.target as HTMLInputElement).value })}
-        >
-          ${this.distributors.map((distributor) => html`<sp-menu-item value=${distributor.id}>${distributor.name}</sp-menu-item>`)}
-        </sp-picker>
-        <sp-picker
-          aria-label="Export format"
-          value=${target.format}
-          @change=${(event: Event) =>
-            this.updateDistribution(index, { format: (event.target as HTMLInputElement).value })}
-        >
-          ${this.distributionFormats.map(
-            (format) => html`<sp-menu-item value=${format.format}>${format.format.toUpperCase()}</sp-menu-item>`,
-          )}
-        </sp-picker>
-        ${this.renderDistributionConfig(target, index)}
-        <sp-action-button
-          size="s"
-          quiet
-          @click=${() => this.removeDistribution(index)}
-          aria-label="Remove distribution"
-        >
-          <sp-icon-close slot="icon"></sp-icon-close>
-        </sp-action-button>
+      <div class="gcr-distribution" role="group" aria-label="Distribution ${index + 1}">
+        <div class="gcr-distribution-header">
+          <h4 class="gcr-subhead">Distribution ${index + 1}</h4>
+          <sp-action-button
+            size="s"
+            quiet
+            @click=${() => this.removeDistribution(index)}
+            aria-label="Remove distribution ${index + 1}"
+          >
+            <sp-icon-close slot="icon"></sp-icon-close>
+          </sp-action-button>
+        </div>
+        <div class="gcr-form-grid">
+          <div class="gcr-field">
+            <sp-field-label for="dist-${index}-destination">Destination</sp-field-label>
+            <sp-picker
+              id="dist-${index}-destination"
+              value=${target.distributorId}
+              @change=${(event: Event) =>
+                this.updateDistribution(index, { distributorId: (event.target as HTMLInputElement).value })}
+            >
+              ${this.distributors.map(
+                (distributor) => html`<sp-menu-item value=${distributor.id}>${distributor.name}</sp-menu-item>`,
+              )}
+            </sp-picker>
+          </div>
+          <div class="gcr-field">
+            <sp-field-label for="dist-${index}-format">Export format</sp-field-label>
+            <sp-picker
+              id="dist-${index}-format"
+              value=${target.format}
+              @change=${(event: Event) =>
+                this.updateDistribution(index, { format: (event.target as HTMLInputElement).value })}
+            >
+              ${this.distributionFormats.map(
+                (format) => html`<sp-menu-item value=${format.format}>${format.format.toUpperCase()}</sp-menu-item>`,
+              )}
+            </sp-picker>
+          </div>
+          ${this.renderDistributionConfig(target, index)}
+        </div>
       </div>
     `;
   }
@@ -543,39 +703,53 @@ export class GcrReportEditor extends LitElement {
 
     if (target.distributorId === 'email') {
       return html`
-        <sp-textfield
-          class="gcr-parameter-label"
-          aria-label="Recipients"
-          value=${value('recipients')}
-          placeholder="a@example.com, b@example.com"
-          @input=${setConfig('recipients')}
-        ></sp-textfield>
-        <sp-textfield
-          class="gcr-parameter-default"
-          aria-label="Subject"
-          value=${value('subject')}
-          placeholder="Subject (optional)"
-          @input=${setConfig('subject')}
-        ></sp-textfield>
+        <div class="gcr-field gcr-field-wide">
+          <sp-field-label for="dist-${index}-recipients" required>Recipients</sp-field-label>
+          <sp-textfield
+            id="dist-${index}-recipients"
+            value=${value('recipients')}
+            placeholder="jane@example.com, team@example.com"
+            @input=${setConfig('recipients')}
+          ></sp-textfield>
+          <sp-help-text size="s">One or more email addresses, separated by commas or semicolons.</sp-help-text>
+        </div>
+        <div class="gcr-field gcr-field-wide">
+          <sp-field-label for="dist-${index}-subject">Subject</sp-field-label>
+          <sp-textfield
+            id="dist-${index}-subject"
+            value=${value('subject')}
+            placeholder="Weekly traffic report"
+            @input=${setConfig('subject')}
+          ></sp-textfield>
+          <sp-help-text size="s">Optional. Falls back to a default subject when empty.</sp-help-text>
+        </div>
       `;
     }
 
     if (target.distributorId === 'filesystem') {
       return html`
-        <sp-textfield
-          class="gcr-parameter-label"
-          aria-label="Directory"
-          value=${value('directory')}
-          placeholder="/var/reports"
-          @input=${setConfig('directory')}
-        ></sp-textfield>
-        <sp-textfield
-          class="gcr-parameter-default"
-          aria-label="File name"
-          value=${value('filename')}
-          placeholder="File name (optional)"
-          @input=${setConfig('filename')}
-        ></sp-textfield>
+        <div class="gcr-field">
+          <sp-field-label for="dist-${index}-directory" required>Directory</sp-field-label>
+          <sp-textfield
+            id="dist-${index}-directory"
+            value=${value('directory')}
+            placeholder="reports/daily"
+            @input=${setConfig('directory')}
+          ></sp-textfield>
+          <sp-help-text size="s">
+            Target folder, resolved inside the allowed root directory configured on the filesystem distributor.
+          </sp-help-text>
+        </div>
+        <div class="gcr-field">
+          <sp-field-label for="dist-${index}-filename">File name</sp-field-label>
+          <sp-textfield
+            id="dist-${index}-filename"
+            value=${value('filename')}
+            placeholder="traffic.csv"
+            @input=${setConfig('filename')}
+          ></sp-textfield>
+          <sp-help-text size="s">Optional. Defaults to <code>&lt;report&gt;-&lt;timestamp&gt;.&lt;ext&gt;</code>.</sp-help-text>
+        </div>
       `;
     }
 

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
@@ -639,7 +639,7 @@ export class GcrReportEditor extends LitElement {
         </div>
 
         ${this.distributors.length === 0
-          ? html`<sp-help-text size="s">No distributors are installed.</sp-help-text>`
+          ? html`<sp-help-text size="s">No distributors are available.</sp-help-text>`
           : this.distributions.length === 0
             ? html`<div class="gcr-empty">
                 No distributions. The result is only stored and available for download.

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-report-editor.ts
@@ -1,12 +1,16 @@
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { ApiError } from '@console/api/client';
-import { deleteReport, getReport, previewReport, saveReport } from '../../api/reports-api';
+import { deleteReport, getReport, listDistributors, previewReport, saveReport } from '../../api/reports-api';
 import type {
+  DistributionTarget,
+  Distributor,
+  ExportFormat,
   PathType,
   ReportParameter,
   ReportParameterType,
   ReportPreviewResponse,
+  ReportSchedule,
   SaveReportRequest,
 } from '../../api/reports-types';
 import { toast } from './gcr-app';
@@ -57,6 +61,17 @@ export class GcrReportEditor extends LitElement {
   @state() private script = DEFAULT_SCRIPT;
   @state() private parameters: ParameterRow[] = [];
 
+  // schedule state
+  @state() private scheduleEnabled = false;
+  @state() private cronExpression = '';
+  @state() private scheduledBy: string | null = null;
+  @state() private scheduleValues: Record<string, string> = {};
+
+  // distribution state
+  @state() private distributions: DistributionTarget[] = [];
+  @state() private distributors: Distributor[] = [];
+  @state() private distributionFormats: ExportFormat[] = [];
+
   // "try out" run state
   @state() private testValues: Record<string, string> = {};
   @state() private preview: ReportPreviewResponse | null = null;
@@ -79,6 +94,19 @@ export class GcrReportEditor extends LitElement {
     // Lazy-load the Monaco-based editor component (and Monaco itself) only when the editor view
     // is actually opened; the list and run views stay lightweight.
     void import('./gcr-code-editor');
+    void this.loadDistributors();
+  }
+
+  private async loadDistributors(): Promise<void> {
+    try {
+      const response = await listDistributors();
+      this.distributors = response.distributors;
+      this.distributionFormats = response.formats;
+    } catch {
+      // distribution is optional; leave the pickers empty if the endpoint is unavailable
+      this.distributors = [];
+      this.distributionFormats = [];
+    }
   }
 
   protected willUpdate(changed: Map<string, unknown>): void {
@@ -114,6 +142,14 @@ export class GcrReportEditor extends LitElement {
       this.parameters = definition.parameters.map((parameter) => ({
         ...parameter,
         options: parameter.options.join(', '),
+      }));
+      this.scheduleEnabled = definition.schedule?.enabled ?? false;
+      this.cronExpression = definition.schedule?.cronExpression ?? '';
+      this.scheduledBy = definition.schedule?.scheduledBy ?? null;
+      this.scheduleValues = { ...(definition.schedule?.parameterValues ?? {}) };
+      this.distributions = (definition.distributions ?? []).map((target) => ({
+        ...target,
+        config: { ...target.config },
       }));
     } catch (error) {
       this.error = error instanceof ApiError ? error.message : 'Could not load report.';
@@ -196,6 +232,24 @@ export class GcrReportEditor extends LitElement {
         rootPath: parameter.type === 'PATH' ? parameter.rootPath || undefined : undefined,
         order: index,
       })),
+      schedule: this.buildSchedule(),
+      distributions: this.distributions.filter((target) => target.distributorId && target.format),
+    };
+  }
+
+  /** Build the schedule payload, or null to remove any existing schedule. runAs and scheduledBy are set
+   *  server-side (a UI schedule always runs as its author), so they are not sent from here. */
+  private buildSchedule(): ReportSchedule | null {
+    const cron = this.cronExpression.trim();
+
+    if (!this.scheduleEnabled && !cron && Object.keys(this.scheduleValues).length === 0) {
+      return null;
+    }
+
+    return {
+      enabled: this.scheduleEnabled,
+      cronExpression: cron || null,
+      parameterValues: this.scheduleValues,
     };
   }
 
@@ -351,8 +405,201 @@ export class GcrReportEditor extends LitElement {
             ? html`<div class="gcr-empty">No parameters. The report runs without input.</div>`
             : this.parameters.map((parameter, index) => this.renderParameterRow(parameter, index))}
         </section>
+
+        ${this.renderSchedule()} ${this.renderDistribution()}
       </div>
     `;
+  }
+
+  private renderSchedule() {
+    return html`
+      <section class="gcr-panel">
+        <div class="gcr-panel-header">
+          <h3>Schedule</h3>
+          <sp-switch
+            ?checked=${this.scheduleEnabled}
+            @change=${(event: Event) => (this.scheduleEnabled = (event.target as HTMLInputElement).checked)}
+          >
+            Run on a schedule
+          </sp-switch>
+        </div>
+
+        ${this.scheduleEnabled
+          ? html`
+              <div class="gcr-form-grid">
+                <div class="gcr-field">
+                  <sp-field-label for="schedule-cron" required>Cron expression</sp-field-label>
+                  <sp-textfield
+                    id="schedule-cron"
+                    value=${this.cronExpression}
+                    placeholder="0 0 6 * * ?"
+                    @input=${(event: Event) => (this.cronExpression = (event.target as HTMLInputElement).value)}
+                  ></sp-textfield>
+                  <sp-help-text size="s">Quartz-style cron (seconds minutes hours day month weekday).</sp-help-text>
+                </div>
+              </div>
+              <sp-help-text size="s">
+                The scheduled report runs as you — with your permissions — so it sees exactly what you can see.
+                ${this.scheduledBy
+                  ? html`Currently scheduled by <code>${this.scheduledBy}</code>.`
+                  : nothing}
+              </sp-help-text>
+              ${this.parameters.length
+                ? html`
+                    <h4 class="gcr-subhead">Scheduled parameter values</h4>
+                    <div class="gcr-form-grid">
+                      ${this.parameters.map((parameter) => this.renderScheduleValue(parameter))}
+                    </div>
+                  `
+                : nothing}
+            `
+          : html`<sp-help-text size="s">The report only runs on demand.</sp-help-text>`}
+      </section>
+    `;
+  }
+
+  private renderScheduleValue(parameter: ParameterRow) {
+    const label = parameter.label || parameter.name || '(unnamed)';
+    const current = this.scheduleValues[parameter.name] ?? parameter.defaultValue ?? '';
+    const onInput = (event: Event) => {
+      this.scheduleValues = { ...this.scheduleValues, [parameter.name]: (event.target as HTMLInputElement).value };
+    };
+    return html`
+      <div class="gcr-field">
+        <sp-field-label for="schedule-value-${parameter.name}" ?required=${parameter.required}>${label}</sp-field-label>
+        <sp-textfield
+          id="schedule-value-${parameter.name}"
+          type=${parameter.type === 'NUMBER' ? 'number' : 'text'}
+          value=${current}
+          @input=${onInput}
+        ></sp-textfield>
+      </div>
+    `;
+  }
+
+  private renderDistribution() {
+    return html`
+      <section class="gcr-panel">
+        <div class="gcr-panel-header">
+          <h3>Distribution</h3>
+          <sp-action-button
+            size="s"
+            ?disabled=${this.distributors.length === 0}
+            @click=${() => this.addDistribution()}
+          >
+            Add distribution
+          </sp-action-button>
+        </div>
+
+        ${this.distributors.length === 0
+          ? html`<sp-help-text size="s">No distributors are installed.</sp-help-text>`
+          : this.distributions.length === 0
+            ? html`<div class="gcr-empty">
+                No distributions. The result is only stored and available for download.
+              </div>`
+            : this.distributions.map((target, index) => this.renderDistributionRow(target, index))}
+      </section>
+    `;
+  }
+
+  private renderDistributionRow(target: DistributionTarget, index: number) {
+    return html`
+      <div class="gcr-parameter-row" role="group" aria-label="Distribution ${index + 1}">
+        <sp-picker
+          aria-label="Distributor"
+          value=${target.distributorId}
+          @change=${(event: Event) =>
+            this.updateDistribution(index, { distributorId: (event.target as HTMLInputElement).value })}
+        >
+          ${this.distributors.map((distributor) => html`<sp-menu-item value=${distributor.id}>${distributor.name}</sp-menu-item>`)}
+        </sp-picker>
+        <sp-picker
+          aria-label="Export format"
+          value=${target.format}
+          @change=${(event: Event) =>
+            this.updateDistribution(index, { format: (event.target as HTMLInputElement).value })}
+        >
+          ${this.distributionFormats.map(
+            (format) => html`<sp-menu-item value=${format.format}>${format.format.toUpperCase()}</sp-menu-item>`,
+          )}
+        </sp-picker>
+        ${this.renderDistributionConfig(target, index)}
+        <sp-action-button
+          size="s"
+          quiet
+          @click=${() => this.removeDistribution(index)}
+          aria-label="Remove distribution"
+        >
+          <sp-icon-close slot="icon"></sp-icon-close>
+        </sp-action-button>
+      </div>
+    `;
+  }
+
+  private renderDistributionConfig(target: DistributionTarget, index: number) {
+    const setConfig = (key: string) => (event: Event) =>
+      this.updateDistributionConfig(index, key, (event.target as HTMLInputElement).value);
+    const value = (key: string) => (target.config[key] as string) ?? '';
+
+    if (target.distributorId === 'email') {
+      return html`
+        <sp-textfield
+          class="gcr-parameter-label"
+          aria-label="Recipients"
+          value=${value('recipients')}
+          placeholder="a@example.com, b@example.com"
+          @input=${setConfig('recipients')}
+        ></sp-textfield>
+        <sp-textfield
+          class="gcr-parameter-default"
+          aria-label="Subject"
+          value=${value('subject')}
+          placeholder="Subject (optional)"
+          @input=${setConfig('subject')}
+        ></sp-textfield>
+      `;
+    }
+
+    if (target.distributorId === 'filesystem') {
+      return html`
+        <sp-textfield
+          class="gcr-parameter-label"
+          aria-label="Directory"
+          value=${value('directory')}
+          placeholder="/var/reports"
+          @input=${setConfig('directory')}
+        ></sp-textfield>
+        <sp-textfield
+          class="gcr-parameter-default"
+          aria-label="File name"
+          value=${value('filename')}
+          placeholder="File name (optional)"
+          @input=${setConfig('filename')}
+        ></sp-textfield>
+      `;
+    }
+
+    return nothing;
+  }
+
+  private addDistribution(): void {
+    const distributorId = this.distributors[0]?.id ?? '';
+    const format = this.distributionFormats[0]?.format ?? '';
+    this.distributions = [...this.distributions, { distributorId, format, config: {} }];
+  }
+
+  private updateDistribution(index: number, patch: Partial<DistributionTarget>): void {
+    this.distributions = this.distributions.map((target, i) => (i === index ? { ...target, ...patch } : target));
+  }
+
+  private updateDistributionConfig(index: number, key: string, value: string): void {
+    this.distributions = this.distributions.map((target, i) =>
+      i === index ? { ...target, config: { ...target.config, [key]: value } } : target,
+    );
+  }
+
+  private removeDistribution(index: number): void {
+    this.distributions = this.distributions.filter((_, i) => i !== index);
   }
 
   private renderTryOut() {

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-report-run.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-report-run.ts
@@ -3,6 +3,7 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { ApiError } from '@console/api/client';
 import {
   deleteExecution,
+  distributeExecution,
   executeReport,
   exportUrl,
   getExecution,
@@ -44,6 +45,7 @@ export class GcrReportRun extends LitElement {
   @state() private loadingPage = false;
   @state() private executions: ReportExecution[] = [];
   @state() private pageSize = 0;
+  @state() private distributing = false;
   /** Repository-path autocomplete suggestions per PATH parameter, keyed by parameter name. */
   @state() private pathSuggestions: Record<string, string[]> = {};
   /** Validation messages for required parameters left empty, keyed by parameter name. */
@@ -233,6 +235,30 @@ export class GcrReportRun extends LitElement {
 
     if (execution.status === 'SUCCESS') {
       await this.loadPage(execution.executionId, 1);
+    }
+  }
+
+  /** Distribute the current execution using the report's configured distribution targets. */
+  private async distributeNow(executionId: string): Promise<void> {
+    if (this.distributing || !this.definition?.distributions.length) {
+      return;
+    }
+
+    this.distributing = true;
+
+    try {
+      const execution = await distributeExecution(executionId, this.definition.distributions);
+      this.execution = execution;
+
+      if (execution.distributionErrors?.length) {
+        toast(this, `Distribution completed with errors: ${execution.distributionErrors.join('; ')}`, 'negative');
+      } else {
+        toast(this, 'Distribution complete.', 'positive');
+      }
+    } catch (error) {
+      toast(this, error instanceof ApiError ? error.message : 'Could not distribute the report.', 'negative');
+    } finally {
+      this.distributing = false;
     }
   }
 
@@ -538,6 +564,18 @@ export class GcrReportRun extends LitElement {
                 </sp-button>
               `,
             )}
+            ${definition.canEdit && definition.distributions.length
+              ? html`
+                  <sp-button
+                    size="s"
+                    variant="secondary"
+                    ?disabled=${this.distributing}
+                    @click=${() => void this.distributeNow(execution.executionId)}
+                  >
+                    ${this.distributing ? 'Distributing…' : 'Distribute now'}
+                  </sp-button>
+                `
+              : nothing}
             ${definition.canEdit
               ? html`
                   <sp-action-button

--- a/extensions/reports/ui.frontend/src/components/reports/gcr-report-run.ts
+++ b/extensions/reports/ui.frontend/src/components/reports/gcr-report-run.ts
@@ -9,6 +9,7 @@ import {
   getExecution,
   getExecutions,
   getReport,
+  getReportsConfig,
   getResultPage,
   listChildPaths,
   resolveDynamicOptions,
@@ -63,6 +64,8 @@ export class GcrReportRun extends LitElement {
   @state() private executions: ReportExecution[] = [];
   @state() private pageSize = 0;
   @state() private distributing = false;
+  // global OSGi flag; when false the "Distribute now" action is hidden
+  @state() private distributionFeatureEnabled = true;
   /** Repository-path autocomplete suggestions per PATH parameter, keyed by parameter name. */
   @state() private pathSuggestions: Record<string, string[]> = {};
   /** Validation messages for required parameters left empty, keyed by parameter name. */
@@ -92,6 +95,9 @@ export class GcrReportRun extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
     this.disposed = false;
+    void getReportsConfig().then((config) => {
+      this.distributionFeatureEnabled = config.distributionEnabled;
+    });
   }
 
   disconnectedCallback(): void {
@@ -751,7 +757,7 @@ export class GcrReportRun extends LitElement {
                 </sp-button>
               `,
             )}
-            ${definition.canEdit && definition.distributions.length
+            ${this.distributionFeatureEnabled && definition.canEdit && definition.distributions.length
               ? html`
                   <sp-button
                     size="s"

--- a/extensions/reports/ui.frontend/src/styles/reports.css
+++ b/extensions/reports/ui.frontend/src/styles/reports.css
@@ -634,6 +634,25 @@ body {
   height: 360px;
 }
 
+/* distribution target card: a bordered group of labelled fields */
+.gcr-distribution {
+  border: 1px solid var(--spectrum-gray-300);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 12px;
+}
+
+.gcr-distribution-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.gcr-distribution-header .gcr-subhead {
+  margin: 0;
+}
+
 .gcr-parameter-row {
   display: flex;
   align-items: center;

--- a/extensions/reports/ui.frontend/src/util/cron.ts
+++ b/extensions/reports/ui.frontend/src/util/cron.ts
@@ -1,0 +1,154 @@
+/**
+ * Small cron helper for the schedule editor: builds Quartz-style expressions from a few friendly presets,
+ * parses an existing expression back into those presets, describes one in plain language, and validates it
+ * with the same rules the server enforces (see the backend CronValidator).
+ *
+ * Quartz form used by the Sling scheduler: 6 or 7 fields
+ * `seconds minutes hours day-of-month month day-of-week [year]`.
+ */
+
+export type CronMode = 'daily' | 'weekday' | 'weekly' | 'monthly' | 'custom';
+
+export interface CronParts {
+  mode: CronMode;
+  /** 0-23 */
+  hour: number;
+  /** 0-59 */
+  minute: number;
+  /** day-of-week token for weekly, e.g. MON */
+  weekday: string;
+  /** 1-31 for monthly */
+  dayOfMonth: number;
+}
+
+export const WEEKDAYS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: 'MON', label: 'Monday' },
+  { value: 'TUE', label: 'Tuesday' },
+  { value: 'WED', label: 'Wednesday' },
+  { value: 'THU', label: 'Thursday' },
+  { value: 'FRI', label: 'Friday' },
+  { value: 'SAT', label: 'Saturday' },
+  { value: 'SUN', label: 'Sunday' },
+];
+
+export const DEFAULT_CRON_PARTS: CronParts = {
+  mode: 'daily',
+  hour: 6,
+  minute: 0,
+  weekday: 'MON',
+  dayOfMonth: 1,
+};
+
+const pad = (value: number): string => String(value).padStart(2, '0');
+
+const weekdayLabel = (token: string): string =>
+  WEEKDAYS.find((day) => day.value === token.toUpperCase())?.label ?? token;
+
+/** Build a cron expression from the preset parts. Returns '' for custom (the raw field is authoritative there). */
+export function buildCron(parts: CronParts): string {
+  const { hour, minute, weekday, dayOfMonth } = parts;
+
+  switch (parts.mode) {
+    case 'daily':
+      return `0 ${minute} ${hour} * * ?`;
+    case 'weekday':
+      return `0 ${minute} ${hour} ? * MON-FRI`;
+    case 'weekly':
+      return `0 ${minute} ${hour} ? * ${weekday}`;
+    case 'monthly':
+      return `0 ${minute} ${hour} ${dayOfMonth} * ?`;
+    default:
+      return '';
+  }
+}
+
+/** Best-effort parse of an expression into preset parts; falls back to custom mode when it isn't a known preset. */
+export function parseCron(expression: string | null | undefined): CronParts {
+  const custom = (): CronParts => ({ ...DEFAULT_CRON_PARTS, mode: 'custom' });
+  const expr = (expression ?? '').trim();
+
+  if (!expr) {
+    return { ...DEFAULT_CRON_PARTS };
+  }
+
+  const fields = expr.split(/\s+/);
+
+  if (fields.length < 6 || fields.length > 7) {
+    return custom();
+  }
+
+  const [seconds, minuteField, hourField, dom, month, dow] = fields;
+  const isInt = (value: string): boolean => /^\d{1,2}$/.test(value);
+
+  // presets only cover a fixed second/minute/hour on any month
+  if (seconds !== '0' || month !== '*' || !isInt(minuteField) || !isInt(hourField)) {
+    return custom();
+  }
+
+  const minute = Number(minuteField);
+  const hour = Number(hourField);
+
+  if (minute > 59 || hour > 23) {
+    return custom();
+  }
+
+  const base = { ...DEFAULT_CRON_PARTS, hour, minute };
+
+  if (dom === '*' && dow === '?') {
+    return { ...base, mode: 'daily' };
+  }
+  if (dom === '?' && dow.toUpperCase() === 'MON-FRI') {
+    return { ...base, mode: 'weekday' };
+  }
+  if (dom === '?' && WEEKDAYS.some((day) => day.value === dow.toUpperCase())) {
+    return { ...base, mode: 'weekly', weekday: dow.toUpperCase() };
+  }
+  if (dow === '?' && isInt(dom) && Number(dom) >= 1 && Number(dom) <= 31) {
+    return { ...base, mode: 'monthly', dayOfMonth: Number(dom) };
+  }
+
+  return custom();
+}
+
+/** Plain-language description of a preset expression (empty string when it can't be described concisely). */
+export function describeCron(expression: string): string {
+  const parts = parseCron(expression);
+  const at = `${pad(parts.hour)}:${pad(parts.minute)}`;
+
+  switch (parts.mode) {
+    case 'daily':
+      return `Runs every day at ${at}.`;
+    case 'weekday':
+      return `Runs every weekday (Mon–Fri) at ${at}.`;
+    case 'weekly':
+      return `Runs every ${weekdayLabel(parts.weekday)} at ${at}.`;
+    case 'monthly':
+      return `Runs on day ${parts.dayOfMonth} of every month at ${at}.`;
+    default:
+      return '';
+  }
+}
+
+/**
+ * Validate an expression with the same rules as the server, so the editor can flag problems before saving.
+ * Returns an error message, or null when the expression is acceptable.
+ */
+export function validateCron(expression: string | null | undefined): string | null {
+  const expr = (expression ?? '').trim();
+
+  if (!expr) {
+    return 'A cron expression is required for an enabled schedule.';
+  }
+
+  const fields = expr.split(/\s+/);
+
+  if (fields.length < 6 || fields.length > 7) {
+    return 'Expected 6 or 7 fields (seconds minutes hours day-of-month month day-of-week [year]).';
+  }
+
+  if (!/^\d{1,2}$/.test(fields[0]) || Number(fields[0]) > 59) {
+    return 'The seconds field must be a fixed value between 0 and 59; sub-minute schedules are not allowed.';
+  }
+
+  return null;
+}

--- a/extensions/reports/ui.frontend/vite.config.ts
+++ b/extensions/reports/ui.frontend/vite.config.ts
@@ -39,11 +39,10 @@ export default defineConfig({
         'reports-panel': resolve(__dirname, 'src/reports-console-panel.ts'),
       },
       output: {
-        // Content-hash the reports entry, its chunks and assets so a changed file gets a fresh URL and an
-        // unchanged one stays cached; the servlet reads the manifest to link the hashed entry. The console
-        // extension module keeps a stable name because the extension provider references it by fixed path.
-        entryFileNames: (chunk) =>
-          chunk.name === 'reports-panel' ? 'assets/[name].js' : 'assets/[name]-[hash].js',
+        // Content-hash the entries (reports page + console panel), chunks and assets so a changed file gets a
+        // fresh URL and an unchanged one stays cached; the servlet and the console resolve the hashed names from
+        // the manifest.
+        entryFileNames: 'assets/[name]-[hash].js',
         chunkFileNames: 'assets/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash][extname]',
         // Monaco is lazy-loaded only by the editor view; keep it in its own stable chunk and keep Vite's

--- a/extensions/reports/ui.frontend/vite.config.ts
+++ b/extensions/reports/ui.frontend/vite.config.ts
@@ -36,11 +36,9 @@ export default defineConfig({
         'reports-panel': resolve(__dirname, 'src/reports-console-panel.ts'),
       },
       output: {
-        // Entry points and their CSS keep stable names so the page servlet / extension provider can reference
-        // them without a manifest; the servlet cache-busts those with a per-deploy ?v token. Shared chunks are
-        // content-hashed, so a code change gets a fresh URL and a redeploy needs no manual browser reload.
+        // Stable file names so reports.html / the extension provider can reference them without a manifest.
         entryFileNames: 'assets/[name].js',
-        chunkFileNames: 'assets/[name]-[hash].js',
+        chunkFileNames: 'assets/[name].js',
         assetFileNames: 'assets/[name][extname]',
         // Monaco is lazy-loaded only by the editor view; keep it in its own stable chunk and keep Vite's
         // preload helper out of it so a dynamic import does not statically drag Monaco in.

--- a/extensions/reports/ui.frontend/vite.config.ts
+++ b/extensions/reports/ui.frontend/vite.config.ts
@@ -36,9 +36,11 @@ export default defineConfig({
         'reports-panel': resolve(__dirname, 'src/reports-console-panel.ts'),
       },
       output: {
-        // Stable file names so reports.html / the extension provider can reference them without a manifest.
+        // Entry points and their CSS keep stable names so the page servlet / extension provider can reference
+        // them without a manifest; the servlet cache-busts those with a per-deploy ?v token. Shared chunks are
+        // content-hashed, so a code change gets a fresh URL and a redeploy needs no manual browser reload.
         entryFileNames: 'assets/[name].js',
-        chunkFileNames: 'assets/[name].js',
+        chunkFileNames: 'assets/[name]-[hash].js',
         assetFileNames: 'assets/[name][extname]',
         // Monaco is lazy-loaded only by the editor view; keep it in its own stable chunk and keep Vite's
         // preload helper out of it so a dynamic import does not statically drag Monaco in.

--- a/extensions/reports/ui.frontend/vite.config.ts
+++ b/extensions/reports/ui.frontend/vite.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
     emptyOutDir: true,
     target: 'es2021',
     chunkSizeWarningLimit: 4000,
+    // emit a manifest so the page servlet can resolve the content-hashed entry (cache-busting without a query
+    // token, which would double-load the entry module); written at the spa root as manifest.json
+    manifest: 'manifest.json',
     rollupOptions: {
       input: {
         // the business-facing reports UI (reports.html)
@@ -36,10 +39,13 @@ export default defineConfig({
         'reports-panel': resolve(__dirname, 'src/reports-console-panel.ts'),
       },
       output: {
-        // Stable file names so reports.html / the extension provider can reference them without a manifest.
-        entryFileNames: 'assets/[name].js',
-        chunkFileNames: 'assets/[name].js',
-        assetFileNames: 'assets/[name][extname]',
+        // Content-hash the reports entry, its chunks and assets so a changed file gets a fresh URL and an
+        // unchanged one stays cached; the servlet reads the manifest to link the hashed entry. The console
+        // extension module keeps a stable name because the extension provider references it by fixed path.
+        entryFileNames: (chunk) =>
+          chunk.name === 'reports-panel' ? 'assets/[name].js' : 'assets/[name]-[hash].js',
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash][extname]',
         // Monaco is lazy-loaded only by the editor view; keep it in its own stable chunk and keep Vite's
         // preload helper out of it so a dynamic import does not statically drag Monaco in.
         manualChunks: (id) => {

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/AssistIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/AssistIT.java
@@ -203,7 +203,9 @@ class AssistIT {
 
         assertTrue(html.contains("<gc-app>"), "Expected modern UI app element");
         assertTrue(html.contains("__GC_CONFIG__"), "Expected injected SPA config");
-        assertTrue(html.contains("/apps/groovyconsole/spa/assets/index.js"), "Expected SPA bundle reference");
+        // the entry is content-hashed (index-<hash>.js), resolved from the Vite manifest for cache-busting
+        assertTrue(html.matches("(?s).*/apps/groovyconsole/spa/assets/index-[\\w-]+\\.js.*"),
+                "Expected the hashed SPA bundle reference");
     }
 
     @Test

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleReportsIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleReportsIT.java
@@ -436,7 +436,9 @@ class GroovyConsoleReportsIT {
 
             String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
             assertTrue(body.contains("<gcr-app>"), "Expected the reports app element");
-            assertTrue(body.contains("/apps/groovyconsole-reports/spa/assets/reports.js"), "Expected the reports bundle script");
+            // the entry is content-hashed (reports-<hash>.js), resolved from the Vite manifest for cache-busting
+            assertTrue(body.matches("(?s).*/apps/groovyconsole-reports/spa/assets/reports-[\\w-]+\\.js.*"),
+                    "Expected the hashed reports bundle script");
         }
     }
 

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleReportsIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleReportsIT.java
@@ -476,7 +476,187 @@ class GroovyConsoleReportsIT {
         doGet("/bin/groovyconsole/reports.json?name=it-delete-report", 404);
     }
 
+    @Test
+    void testDistributorsListed() throws Exception {
+        JsonObject result = doGet("/bin/groovyconsole/reports/distributors.json", 200);
+
+        JsonArray distributors = result.getAsJsonArray("distributors");
+        // the filesystem distributor is always available; the email distributor is AEM-only (it binds
+        // com.day.cq.mailer.MailService, which is absent on plain Sling), so it is not asserted here
+        assertTrue(containsId(distributors, "filesystem"), "Expected the filesystem distributor");
+
+        // the endpoint also surfaces the available export formats used to render a distribution
+        assertTrue(containsFormat(result.getAsJsonArray("formats"), "csv"), "Expected csv format");
+    }
+
+    @Test
+    void testScheduleAndDistributionRoundTripThenRemoval() throws Exception {
+        String name = "it-scheduled";
+
+        JsonObject schedule = new JsonObject();
+        schedule.addProperty("enabled", true);
+        schedule.addProperty("cronExpression", "0 0 6 * * ?");
+        // blank runAs => the report runs as the reports service user; a client-supplied scheduledBy is ignored
+        schedule.addProperty("runAs", "");
+        schedule.addProperty("scheduledBy", "attacker");
+        JsonObject scheduleValues = new JsonObject();
+        scheduleValues.addProperty("greeting", "scheduled");
+        schedule.add("parameterValues", scheduleValues);
+
+        JsonObject config = new JsonObject();
+        config.addProperty("directory", "out");
+        JsonObject target = new JsonObject();
+        target.addProperty("distributorId", "filesystem");
+        target.addProperty("format", "csv");
+        target.add("config", config);
+        JsonArray distributions = new JsonArray();
+        distributions.add(target);
+
+        JsonObject definition = new JsonObject();
+        definition.addProperty("name", name);
+        definition.addProperty("title", "IT Scheduled");
+        definition.addProperty("script", "def d = report.data(); d.column('A'); d.row('x'); d");
+        definition.add("parameters", new JsonArray());
+        definition.add("schedule", schedule);
+        definition.add("distributions", distributions);
+
+        try (CloseableHttpResponse response = doPostJson("/bin/groovyconsole/reports", definition.toString())) {
+            assertEquals(200, response.getStatusLine().getStatusCode(),
+                    "Could not save scheduled report: " + response.getStatusLine());
+        }
+
+        JsonObject saved = doGet("/bin/groovyconsole/reports.json?name=" + name, 200);
+
+        JsonObject savedSchedule = saved.getAsJsonObject("schedule");
+        assertTrue(savedSchedule.get("enabled").getAsBoolean());
+        assertEquals("0 0 6 * * ?", savedSchedule.get("cronExpression").getAsString());
+        // scheduledBy is set server-side to the requesting user, never the client-supplied value
+        assertEquals("admin", savedSchedule.get("scheduledBy").getAsString());
+        assertEquals("scheduled", savedSchedule.getAsJsonObject("parameterValues").get("greeting").getAsString());
+
+        JsonArray savedDistributions = saved.getAsJsonArray("distributions");
+        assertEquals(1, savedDistributions.size());
+        assertEquals("filesystem", savedDistributions.get(0).getAsJsonObject().get("distributorId").getAsString());
+        assertEquals("csv", savedDistributions.get(0).getAsJsonObject().get("format").getAsString());
+        assertEquals("out", savedDistributions.get(0).getAsJsonObject().getAsJsonObject("config")
+                .get("directory").getAsString());
+
+        // re-save without a schedule/distributions: both must be removed (and the cron job unscheduled)
+        JsonObject withoutSchedule = new JsonObject();
+        withoutSchedule.addProperty("name", name);
+        withoutSchedule.addProperty("title", "IT Scheduled");
+        withoutSchedule.addProperty("script", "def d = report.data(); d.column('A'); d.row('x'); d");
+        withoutSchedule.add("parameters", new JsonArray());
+
+        try (CloseableHttpResponse response = doPostJson("/bin/groovyconsole/reports", withoutSchedule.toString())) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+        }
+
+        JsonObject cleared = doGet("/bin/groovyconsole/reports.json?name=" + name, 200);
+        assertTrue(cleared.get("schedule").isJsonNull(), "schedule must be removed when omitted");
+        assertEquals(0, cleared.getAsJsonArray("distributions").size(), "distributions must be removed when omitted");
+    }
+
+    @Test
+    void testScheduleWithInvalidCronRejected() throws Exception {
+        String name = "it-bad-cron";
+
+        JsonObject schedule = new JsonObject();
+        schedule.addProperty("enabled", true);
+        // sub-minute schedule: rejected before anything is persisted
+        schedule.addProperty("cronExpression", "* * * * * ?");
+
+        JsonObject definition = new JsonObject();
+        definition.addProperty("name", name);
+        definition.addProperty("title", "Bad Cron");
+        definition.addProperty("script", "report.data()");
+        definition.add("parameters", new JsonArray());
+        definition.add("schedule", schedule);
+
+        try (CloseableHttpResponse response = doPostJson("/bin/groovyconsole/reports", definition.toString())) {
+            assertEquals(400, response.getStatusLine().getStatusCode(),
+                    "sub-minute cron must be rejected: " + response.getStatusLine());
+        }
+
+        // nothing should have been created
+        doGet("/bin/groovyconsole/reports.json?name=" + name, 404);
+    }
+
+    @Test
+    void testManualDistributeToDisabledFilesystemRecordsError() throws Exception {
+        createReport("it-distribute", "def d = report.data(); d.column('A'); d.row('x'); d");
+        String id = execute("it-distribute", new JsonObject()).get("executionId").getAsString();
+
+        JsonObject config = new JsonObject();
+        config.addProperty("directory", "out");
+        JsonObject target = new JsonObject();
+        target.addProperty("distributorId", "filesystem");
+        target.addProperty("format", "csv");
+        target.add("config", config);
+        JsonArray targets = new JsonArray();
+        targets.add(target);
+
+        JsonObject body = new JsonObject();
+        body.addProperty("executionId", id);
+        body.add("targets", targets);
+
+        // the filesystem distributor is disabled by default, so distribution fails but the run itself does not:
+        // the endpoint returns 200 and records the failure on the execution
+        try (CloseableHttpResponse response = doPostJson("/bin/groovyconsole/reports/distribute", body.toString())) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+
+            JsonObject execution = parse(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8));
+            JsonArray errors = execution.getAsJsonArray("distributionErrors");
+
+            assertNotNull(errors, "Expected distribution errors to be recorded");
+            assertFalse(errors.isEmpty(), "Expected a recorded distribution failure");
+            assertTrue(errors.get(0).getAsString().toLowerCase().contains("disabled"),
+                    "Expected the disabled-distributor error: " + errors);
+        }
+    }
+
+    @Test
+    void testManualDistributeUnknownExecutionReturns404() throws Exception {
+        JsonObject target = new JsonObject();
+        target.addProperty("distributorId", "filesystem");
+        target.addProperty("format", "csv");
+        target.add("config", new JsonObject());
+        JsonArray targets = new JsonArray();
+        targets.add(target);
+
+        JsonObject body = new JsonObject();
+        body.addProperty("executionId", "does-not-exist");
+        body.add("targets", targets);
+
+        try (CloseableHttpResponse response = doPostJson("/bin/groovyconsole/reports/distribute", body.toString())) {
+            assertEquals(404, response.getStatusLine().getStatusCode());
+        }
+    }
+
+    @Test
+    void testManualDistributeWithoutTargetsReturns400() throws Exception {
+        String id = ensureExecuted();
+
+        JsonObject body = new JsonObject();
+        body.addProperty("executionId", id);
+        body.add("targets", new JsonArray());
+
+        try (CloseableHttpResponse response = doPostJson("/bin/groovyconsole/reports/distribute", body.toString())) {
+            assertEquals(400, response.getStatusLine().getStatusCode());
+        }
+    }
+
     // internals
+
+    private static boolean containsId(JsonArray items, String id) {
+        for (int i = 0; i < items.size(); i++) {
+            if (id.equals(items.get(i).getAsJsonObject().get("id").getAsString())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private static boolean isReportsApiReady() {
         try {

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleReportsIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleReportsIT.java
@@ -483,11 +483,12 @@ class GroovyConsoleReportsIT {
         JsonObject result = doGet("/bin/groovyconsole/reports/distributors.json", 200);
 
         JsonArray distributors = result.getAsJsonArray("distributors");
-        // the filesystem distributor is always available; the email distributor is AEM-only (it binds
-        // com.day.cq.mailer.MailService, which is absent on plain Sling), so it is not asserted here
-        assertTrue(containsId(distributors, "filesystem"), "Expected the filesystem distributor");
+        // only usable distributors are listed: on a plain Sling instance the filesystem distributor is disabled
+        // by default and the email distributor has no mail service, so neither is offered as a destination
+        assertFalse(containsId(distributors, "filesystem"), "the disabled filesystem distributor must not be listed");
+        assertFalse(containsId(distributors, "email"), "the email distributor is unavailable without a mail service");
 
-        // the endpoint also surfaces the available export formats used to render a distribution
+        // the endpoint still surfaces the available export formats used to render a distribution
         assertTrue(containsFormat(result.getAsJsonArray("formats"), "csv"), "Expected csv format");
     }
 

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleReportsIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/GroovyConsoleReportsIT.java
@@ -453,8 +453,9 @@ class GroovyConsoleReportsIT {
             assertEquals(200, response.getStatusLine().getStatusCode());
 
             String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-            assertTrue(body.contains("/apps/groovyconsole-reports/spa/assets/reports-panel.js"),
-                    "Expected the reports panel module in the console UI extensions");
+            // the panel module is content-hashed (reports-panel-<hash>.js), resolved from the manifest
+            assertTrue(body.matches("(?s).*/apps/groovyconsole-reports/spa/assets/reports-panel-[\\w-]+\\.js.*"),
+                    "Expected the hashed reports panel module in the console UI extensions");
         }
     }
 

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/MigrationIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/MigrationIT.java
@@ -66,6 +66,36 @@ class MigrationIT {
     }
 
     @Test
+    void testMigrationPageServedWithHashedEntry() throws Exception {
+        String body = getHtml("/apps/groovyconsole/migrations.html");
+
+        assertTrue(body.contains("<gcm-app>"), "Expected the migration app element");
+        // the entry is content-hashed (migration-<hash>.js), resolved from the Vite manifest for cache-busting
+        assertTrue(body.matches("(?s).*/apps/groovyconsole-migration/spa/assets/migration-[\\w-]+\\.js.*"),
+                "Expected the hashed migration bundle script");
+    }
+
+    @Test
+    void testConsoleAnnouncesMigrationUiExtensionHashed() throws Exception {
+        // the modern console injects the migration panel module URL, resolved to its content-hashed name
+        String body = getHtml("/apps/groovyconsole.modern.html");
+
+        assertTrue(body.matches("(?s).*/apps/groovyconsole-migration/spa/assets/migration-panel-[\\w-]+\\.js.*"),
+                "Expected the hashed migration panel module in the console UI extensions");
+    }
+
+    private static String getHtml(String path) throws IOException {
+        HttpGet get = new HttpGet(BASE_URL + path);
+        get.addHeader("Authorization", AUTH_HEADER);
+
+        try (CloseableHttpResponse response = httpClient.execute(get)) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+
+            return EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
     @Order(1)
     void testSyncRunExecutesNewScript() throws Exception {
         createMigrationScript("001-first.groovy", "println 'migration one'");

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/MigrationIndexAuditIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/MigrationIndexAuditIT.java
@@ -48,10 +48,15 @@ class MigrationIndexAuditIT {
     private static CloseableHttpClient httpClient;
 
     @BeforeAll
-    static void setUp() throws IOException {
+    static void setUp() {
         httpClient = HttpClients.createDefault();
         waitForReadiness(300);
-        deployMigrationScript();
+        // The migration scripts base (/conf/groovyconsole/scripts/migration) is provisioned asynchronously, and can
+        // still be missing when the console endpoint first reports ready — the deploy then 404s. Retry until it lands.
+        await().atMost(120, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .untilAsserted(MigrationIndexAuditIT::deployMigrationScript);
     }
 
     @AfterAll

--- a/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/MigrationIndexAuditIT.java
+++ b/it.tests/src/test/java/be/orbinson/aem/groovy/console/it/MigrationIndexAuditIT.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,8 +39,10 @@ class MigrationIndexAuditIT {
     private static final String AUTH_HEADER =
             "Basic " + Base64.encodeBase64String("admin:admin".getBytes(StandardCharsets.UTF_8));
 
-    // A migration script under the migration extension's default scripts base path.
-    private static final String SCRIPT_NAME = "it-index-audit.groovy";
+    // A migration script under the migration extension's default scripts base path. The ".always." token makes it
+    // re-run on every migration run, so the run this test triggers always executes and audits it even if a
+    // concurrent/background migration run (from another suite test still draining) executed it first.
+    private static final String SCRIPT_NAME = "it-index-audit.always.groovy";
     private static final String SCRIPT_PATH = "/conf/groovyconsole/scripts/migration/" + SCRIPT_NAME;
 
     private static CloseableHttpClient httpClient;
@@ -61,8 +64,13 @@ class MigrationIndexAuditIT {
 
     @Test
     void migrationRunReportsIndexUsagePerScript() throws Exception {
-        JsonObject run = post("/bin/groovyconsole/migration",
-                param("measureIndexUsage", "true"));
+        // A migration run is rejected with 409 while another run is in progress or queued (the service serialises
+        // runs). Other migration tests in the suite may still be draining an async run, so retry until our run is
+        // accepted rather than failing on that transient conflict.
+        JsonObject run = await().atMost(120, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .until(() -> post("/bin/groovyconsole/migration", param("measureIndexUsage", "true")), notNullValue());
         assertNotNull(run, "no response from migration run");
 
         JsonArray results = run.getAsJsonArray("results");

--- a/ui.apps.aem/src/main/content/META-INF/vault/filter.xml
+++ b/ui.apps.aem/src/main/content/META-INF/vault/filter.xml
@@ -2,7 +2,9 @@
 <workspaceFilter version="1.0">
     <filter root="/apps/groovyconsole-aem"/>
 
-    <filter root="/apps/cq/core/content/nav">
+    <!-- merge mode: add the console's Tools entry without replacing the shared nav folders, so it never wipes
+         sibling entries contributed by the reports/migration extensions (and vice versa) -->
+    <filter root="/apps/cq/core/content/nav" mode="merge">
         <include pattern="/apps/cq/core/content/nav"/>
         <include pattern="/apps/cq/core/content/nav/tools"/>
         <include pattern="/apps/cq/core/content/nav/tools/general"/>

--- a/ui.apps.aem/src/main/content/META-INF/vault/filter.xml
+++ b/ui.apps.aem/src/main/content/META-INF/vault/filter.xml
@@ -2,12 +2,14 @@
 <workspaceFilter version="1.0">
     <filter root="/apps/groovyconsole-aem"/>
 
-    <!-- merge mode: add the console's Tools entry without replacing the shared nav folders, so it never wipes
-         sibling entries contributed by the reports/migration extensions (and vice versa) -->
+    <!-- merge the shared AEM Tools > General nav folders: create them if missing but never replace them, so
+         installing this package never removes the reports/migration extensions' sibling entries -->
     <filter root="/apps/cq/core/content/nav" mode="merge">
         <include pattern="/apps/cq/core/content/nav"/>
         <include pattern="/apps/cq/core/content/nav/tools"/>
         <include pattern="/apps/cq/core/content/nav/tools/general"/>
-        <include pattern="/apps/cq/core/content/nav/tools/general/groovyconsole(.*)?"/>
     </filter>
+    <!-- own only this leaf entry, so it is always (re)created even under a pre-existing shared folder and never
+         touches sibling entries -->
+    <filter root="/apps/cq/core/content/nav/tools/general/groovyconsole"/>
 </workspaceFilter>

--- a/ui.apps/src/main/content/jcr_root/apps/groovyconsole/components/console/modern.html
+++ b/ui.apps/src/main/content/jcr_root/apps/groovyconsole/components/console/modern.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en"
+      data-sly-use.config="be.orbinson.aem.groovy.console.components.ModernConsoleConfig">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>${properties['jcr:title'] || 'Groovy Console'}</title>
-    <link rel="stylesheet" href="${request.contextPath @ context='unsafe'}/apps/groovyconsole/spa/assets/monaco.css"/>
-    <link rel="stylesheet" href="${request.contextPath @ context='unsafe'}/apps/groovyconsole/spa/assets/index.css"/>
+    <link data-sly-repeat.sheet="${config.styleSheets}" rel="stylesheet" href="${sheet @ context='unsafe'}"/>
 </head>
-<body data-sly-use.config="be.orbinson.aem.groovy.console.components.ModernConsoleConfig">
+<body>
 <gc-app></gc-app>
 <script>window.__GC_CONFIG__ = ${config.json @ context='unsafe'};</script>
-<script type="module" src="${request.contextPath @ context='unsafe'}/apps/groovyconsole/spa/assets/index.js"></script>
+<script type="module" src="${config.scriptSrc @ context='unsafe'}"></script>
 </body>
 </html>

--- a/ui.frontend/src/components/gc-app-bar.ts
+++ b/ui.frontend/src/components/gc-app-bar.ts
@@ -65,7 +65,7 @@ export class GcAppBar extends LitElement {
         </span>
 
         <div class="gc-app-bar-actions">
-          <div class="gc-run-group">
+          <div class="gc-run-group ${this.runActions.length ? 'gc-run-group--split' : ''}">
             <sp-button variant="accent" size="m" ?disabled=${running} @click=${() => this.emit('gc-run')}>
               ${running
                 ? html`<sp-progress-circle indeterminate size="s" slot="icon"></sp-progress-circle> Running…`

--- a/ui.frontend/src/styles/app.css
+++ b/ui.frontend/src/styles/app.css
@@ -129,8 +129,13 @@ body {
   background: rgba(0, 0, 0, 0.35);
 }
 
-/* direct child only: the chevron sits nested inside .gc-overflow and must not pick up the left rounding */
+/* a lone Run button is a full pill; only when the split chevron is present is its right edge squared so the two
+   segments join (direct child only — the chevron sits nested inside .gc-overflow) */
 .gc-run-group > sp-button {
+  --mod-button-border-radius: 16px;
+}
+
+.gc-run-group--split > sp-button {
   --mod-button-border-radius: 16px 0 0 16px;
 }
 

--- a/ui.frontend/vite.config.ts
+++ b/ui.frontend/vite.config.ts
@@ -20,16 +20,20 @@ export default defineConfig({
     emptyOutDir: true,
     target: 'es2021',
     chunkSizeWarningLimit: 4000,
+    // emit a manifest so the console page (ModernConsoleConfig) can link the content-hashed entry for
+    // cache-busting; written at the spa root as manifest.json
+    manifest: 'manifest.json',
     rollupOptions: {
       input: {
         // console SPA (modern.html)
         index: resolve(__dirname, 'index.html'),
       },
       output: {
-        // Stable file names so modern.html can link them without a manifest.
-        entryFileNames: 'assets/[name].js',
-        chunkFileNames: 'assets/[name].js',
-        assetFileNames: 'assets/[name][extname]',
+        // Content-hash the entry, chunks and assets so a changed file gets a fresh URL and an unchanged one stays
+        // cached; the console page resolves the hashed names (incl. the Monaco chunk's CSS) from the manifest.
+        entryFileNames: 'assets/[name]-[hash].js',
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash][extname]',
         // Give the Monaco chunk a stable name the HTL entry page can link to.  Vite's preload helper must
         // NOT end up inside the monaco chunk, or every dynamic import would statically drag Monaco in.
         manualChunks: (id) => {

--- a/ui.tests/specs/reports.spec.ts
+++ b/ui.tests/specs/reports.spec.ts
@@ -68,6 +68,24 @@ test.describe('reports', () => {
     await expect(namesRow).toContainText('alpha, beta');
   });
 
+  test('opens the edit view with a working code editor', async ({ page }) => {
+    // the edit view lazy-loads the Monaco code editor; the sample report also has a PATH parameter, so the
+    // path browser lazy-loads too. Both must initialise — this guards against a chunk-load clash that leaves
+    // the <gcr-code-editor> host element on the page but never upgraded (no Monaco, no script field).
+    await page.goto(`${REPORTS_URL}#/report/sample-content-listing/edit`);
+
+    await expect(page.getByRole('heading', { name: new RegExp(`Edit: ${SAMPLE_TITLE}`) })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // the Monaco editor must actually render, not just the host element
+    await expect(page.locator('gcr-code-editor .monaco-editor')).toBeVisible({ timeout: 30_000 });
+
+    // the scheduling and distribution sections are part of the editor
+    await expect(page.getByRole('heading', { name: 'Schedule' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Distribution' })).toBeVisible();
+  });
+
   test('registers a Reports panel in the modern console', async ({ page }) => {
     await page.goto(MODERN_URL);
 


### PR DESCRIPTION
## Summary

Reports can now run **unattended on a cron schedule** and deliver their results through a **pluggable distribution SPI**, available for both scheduled and manual runs.

## Scheduling
- Per-report cron schedule on the definition, reconciled to a Sling scheduled job (persistent, cluster-safe) on save/delete.
- Cron expressions are validated before persistence (Quartz 6/7-field form); **sub-minute schedules are rejected**.
- **Run-as identity, two paths:**
  - **UI/API schedules run as their author** — `runAs`/`scheduledBy` are forced server-side to the requesting user (body values ignored), enabled by a *self-scoped* impersonation grant. A user can only ever schedule a report to run as themselves, so scheduling can never be used to gain access.
  - **Code-deployed reports** are auto-discovered from the immutable `/apps/groovyconsole-reports-definitions` drop-zone (startup scan + resource-change listener) and run as the dedicated `aem-groovy-console-reports-executor` service user (reads `/content`). Because `/apps` can't be written at runtime, this is the trust boundary for the executor identity.
- Jobs are keyed by definition path, so `/conf` and `/apps` definitions never collide.

## Distribution
- `ReportDistributor` / `ReportDistributorRegistry` SPI mirroring the exporter SPI; distributors render through any registered export format (CSV, XLSX, …).
- **Email** distributor (AEM mail service) with an optional recipient-domain allowlist (empty = send anywhere); **Filesystem** distributor sandboxed to a configured root via canonical-path check and disabled by default.
- Targets stored on the definition, applied automatically on scheduled completion and on demand via **Distribute now**; a distribution failure is recorded on the execution (`distributionErrors`) but never fails the run.

## Security notes
- The trust boundary for authoring executable report scripts is JCR write access to `/conf/groovyconsole/reports` (unchanged); the console-permission check is defense-in-depth on top.
- Forged `runAs` fails closed (impersonation is only ever self-granted); manual runs always use the caller's own resolver.

## Verification
- `mvn clean install` green across all modules (aemanalyser on).
- 47 reports-bundle unit tests green.
- 26/26 reports integration tests green on the Sling Starter.

Includes editor UI for schedules and distribution targets, and README documentation.